### PR TITLE
NEW: Activating all containers, even without IPs.

### DIFF
--- a/enforcer/datapath.go
+++ b/enforcer/datapath.go
@@ -127,7 +127,7 @@ func (d *datapathEnforcer) Enforce(contextID string, puInfo *policy.PUInfo) erro
 }
 
 func (d *datapathEnforcer) doCreatePU(contextID string, puInfo *policy.PUInfo) error {
-	ip, ok := puInfo.Runtime.DefaultIPAddress()
+	ip, ok := puInfo.Policy.DefaultIPAddress()
 	if !ok {
 		return fmt.Errorf("No Default IP for PU, not enforcing.")
 	}

--- a/enforcer/datapath_test.go
+++ b/enforcer/datapath_test.go
@@ -156,6 +156,7 @@ func TestPacketHandling(t *testing.T) {
 			ip1 := make(map[string]string)
 			ip1["bridge"] = "164.67.228.152"
 			puInfo1.Runtime.SetIPAddresses(ip1)
+			puInfo1.Policy.PolicyIPs = []string{"164.67.228.152"}
 			puInfo1.Policy.PolicyTags[TransmitterLabel] = "value"
 			puInfo1.Policy.Rules = append(puInfo1.Policy.Rules, tagSelector)
 
@@ -164,6 +165,7 @@ func TestPacketHandling(t *testing.T) {
 			ip2 := make(map[string]string)
 			ip2["bridge"] = "10.1.10.76"
 			puInfo2.Runtime.SetIPAddresses(ip2)
+			puInfo2.Policy.PolicyIPs = []string{"10.1.10.76"}
 			puInfo2.Policy.PolicyTags[TransmitterLabel] = "value"
 			puInfo1.Policy.Rules = append(puInfo1.Policy.Rules, tagSelector)
 

--- a/enforcer/datapath_test.go
+++ b/enforcer/datapath_test.go
@@ -274,6 +274,7 @@ func TestCacheState(t *testing.T) {
 	}
 
 	puInfo.Runtime.SetIPAddresses(map[string]string{"bridge": "127.0.0.1"})
+	puInfo.Policy.PolicyIPs = []string{"127.0.0.1"}
 
 	// Should  not fail:  IP is valid
 	err = enforcer.Enforce(contextID, puInfo)

--- a/example/common/common.go
+++ b/example/common/common.go
@@ -52,7 +52,19 @@ func (p *CustomPolicyResolver) ResolvePolicy(context string, runtimeInfo policy.
 	containerPolicyInfo.EgressACLs = []policy.IPRule{egress}
 
 	p.cache[context] = runtimeInfo
+
+	// Use all the labels from Docker
 	containerPolicyInfo.PolicyTags = runtimeInfo.Tags()
+
+	// Use the bridge IP from Docker.
+	ip, ok := runtimeInfo.DefaultIPAddress()
+	if ok {
+		containerPolicyInfo.PolicyIPs = []string{ip}
+	} else {
+		containerPolicyInfo.PolicyIPs = []string{}
+	}
+
+	// Police the container
 	containerPolicyInfo.TriremeAction = policy.Police
 
 	for i, selector := range containerPolicyInfo.Rules {

--- a/monitor/docker.go
+++ b/monitor/docker.go
@@ -294,8 +294,8 @@ func (d *dockerMonitor) addOrUpdateDockerContainer(dockerInfo *types.ContainerJS
 
 	ip, ok := runtimeInfo.DefaultIPAddress()
 	if !ok || ip == "" {
-		glog.V(2).Infof("IP Not present in container, not policing")
-		return nil
+		glog.V(2).Infof("IP Not present in container, Attempting activation")
+		ip = ""
 	}
 
 	returnChan := d.puHandler.HandleCreate(contextID, runtimeInfo)

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -83,6 +83,8 @@ type PUPolicy struct {
 	EgressACLs []IPRule
 	// PolicyTags are the tags that will be sent on the wire and used for policing.
 	PolicyTags TagsMap
+	// PolicyIPs are the endpoint PU IP that we want to apply Trireme to. By default this would represent the same set of IPs as the Runtime would give you.
+	PolicyIPs []string
 	// Rules is the set of rules that implement the label matching.
 	Rules []TagSelector
 	// Extensions is an interface to a data structure that allows the policy supervisor
@@ -155,6 +157,20 @@ func (r *PURuntime) SetTags(tags TagsMap) {
 	r.tags = tags
 }
 
+// IPAddresses returns all the IP addresses for the processing unit
+func (r *PUPolicy) IPAddresses() []string {
+	return r.PolicyIPs
+}
+
+// DefaultIPAddress returns the default IP address for the processing unit
+func (r *PUPolicy) DefaultIPAddress() (string, bool) {
+	if len(r.PolicyIPs) == 0 {
+		return "", false
+	}
+	ip := r.PolicyIPs[0]
+	return ip, true
+}
+
 // PUInfo  captures all policy information related to a connection
 type PUInfo struct {
 	// ContextID is the ID of the container that the policy applies to
@@ -179,6 +195,7 @@ func NewPUPolicy() *PUPolicy {
 		EgressACLs:  []IPRule{},
 		Rules:       []TagSelector{},
 		PolicyTags:  map[string]string{},
+		PolicyIPs:   []string{},
 	}
 }
 

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -167,6 +167,9 @@ func (r *PUPolicy) DefaultIPAddress() (string, bool) {
 	if len(r.PolicyIPs) == 0 {
 		return "", false
 	}
+	if r.PolicyIPs[0] == "" {
+		return "", false
+	}
 	ip := r.PolicyIPs[0]
 	return ip, true
 }

--- a/trireme_test.go
+++ b/trireme_test.go
@@ -35,6 +35,7 @@ func doTestCreate(t *testing.T, trireme Trireme, tresolver TestPolicyResolver, t
 		}
 
 		tpolicy := policy.NewPUPolicy()
+		tpolicy.PolicyIPs = []string{"127.0.0.1"}
 		resolverCount++
 		return tpolicy, nil
 	})
@@ -253,6 +254,7 @@ func TestSimpleUpdate(t *testing.T) {
 	// Generate a new Policy ...
 
 	newPolicy := policy.NewPUPolicy()
+	newPolicy.PolicyIPs = []string{"127.0.0.1"}
 	doTestUpdate(t, trireme, tresolver, tsupervisor, tenforcer, tmonitor, contextID, runtime, newPolicy)
 }
 


### PR DESCRIPTION
The goal here is that even if an IP is not directly visible through the Docker API/Event API (CNI for example), the container should be activated and it is the responsibility of the PolicyResolver to figure out the IP. This is typically used for Kubernetes Integration.

Detailed additions:
Adding IPs field into the PUPolicy
Validating the IP received back inside the PUPolicy
Using the PUPolicy IPs instead of the Runtime IPs.