### PR TITLE
NEW: SupervisorTests + Appending all Net and App rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: go
+language: go
+sudo: required
+dist: trusty
+
 go:
  - 1.7.3
 
@@ -7,6 +11,12 @@ addons:
      packages:
        - libnetfilter-queue-dev
        - iptables
+
+env:
+  global:
+    - TOOLS_CMD=golang.org/x/tools/cmd
+    - PATH=$GOROOT/bin:$PATH
+    - SUDO_PERMITTED=1
 
 before_install:
   - go get -u gopkg.in/alecthomas/gometalinter.v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: go
-language: go
 sudo: required
 dist: trusty
 
@@ -23,6 +22,7 @@ before_install:
   - gometalinter.v1 --install
 
 script:
+ - sudo modprobe iptables_raw
  - gometalinter.v1 --disable-all --enable=vet --enable=vetshadow --enable=golint --enable=structcheck --enable=aligncheck --enable=deadcode --enable=ineffassign --enable=gotype --enable=goimports --enable=varcheck --enable=interfacer --enable=goconst --enable=gosimple --enable=staticcheck --enable=unused --enable=misspell --deadline=30s
  - ./.test.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,8 @@ before_install:
   - gometalinter.v1 --install
 
 script:
- - sudo modprobe iptables_raw
  - gometalinter.v1 --disable-all --enable=vet --enable=vetshadow --enable=golint --enable=structcheck --enable=aligncheck --enable=deadcode --enable=ineffassign --enable=gotype --enable=goimports --enable=varcheck --enable=interfacer --enable=goconst --enable=gosimple --enable=staticcheck --enable=unused --enable=misspell --deadline=30s
- - sudo ./.test.sh
+ - ./.test.sh
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 script:
  - sudo modprobe iptables_raw
  - gometalinter.v1 --disable-all --enable=vet --enable=vetshadow --enable=golint --enable=structcheck --enable=aligncheck --enable=deadcode --enable=ineffassign --enable=gotype --enable=goimports --enable=varcheck --enable=interfacer --enable=goconst --enable=gosimple --enable=staticcheck --enable=unused --enable=misspell --deadline=30s
- - ./.test.sh
+ - sudo ./.test.sh
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -36,8 +36,14 @@ func NewTriremeWithDockerMonitor(
 		eventCollector = &collector.DefaultCollector{}
 	}
 
+	// Make sure that the iptables command is accessible. Panic if its not there.
+	ipt, err := supervisor.NewGoIPTablesProvider()
+	if err != nil {
+		panic("Failed to load Go-Iptables: ", err)
+	}
+
 	enforcer := enforcer.NewDefaultDatapathEnforcer(serverID, eventCollector, secrets)
-	supervisor, _ := supervisor.NewIPTablesSupervisor(eventCollector, enforcer, networks)
+	supervisor, _ := supervisor.NewIPTablesSupervisor(eventCollector, enforcer, ipt, networks)
 	trireme := trireme.NewTrireme(serverID, resolver, supervisor, enforcer)
 	monitor := monitor.NewDockerMonitor(DefaultDockerSocketType, DefaultDockerSocket, trireme, nil, eventCollector, syncAtStart)
 

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -4,6 +4,7 @@ package configurator
 
 import (
 	"crypto/ecdsa"
+	"fmt"
 
 	"github.com/aporeto-inc/trireme"
 	"github.com/aporeto-inc/trireme/collector"
@@ -39,7 +40,8 @@ func NewTriremeWithDockerMonitor(
 	// Make sure that the iptables command is accessible. Panic if its not there.
 	ipt, err := supervisor.NewGoIPTablesProvider()
 	if err != nil {
-		panic("Failed to load Go-Iptables: ", err)
+		fmt.Printf("Failed to load Go-Iptables: %s", err)
+		panic("Failed to load Go-Iptables: ")
 	}
 
 	enforcer := enforcer.NewDefaultDatapathEnforcer(serverID, eventCollector, secrets)

--- a/supervisor/iptables.go
+++ b/supervisor/iptables.go
@@ -82,8 +82,8 @@ func NewIPTablesSupervisor(collector collector.EventCollector, enforcer enforcer
 	return s, nil
 }
 
-// AddPU creates a mapping between an IP address and the corresponding labels
-// and the invokes the various handlers that process all policies.
+// Supervise creates a mapping between an IP address and the corresponding labels.
+// it invokes the various handlers that process the parameter policy.
 func (s *iptablesSupervisor) Supervise(contextID string, containerInfo *policy.PUInfo) error {
 	if containerInfo == nil || containerInfo.Policy == nil || containerInfo.Runtime == nil {
 		return fmt.Errorf("Runtime, Policy and ContainerInfo should not be nil")
@@ -493,8 +493,8 @@ func (s *iptablesSupervisor) addAppACLs(chain string, ip string, rules []policy.
 
 	for i := range rules {
 
-		if err := s.ipt.Insert(
-			appAckPacketIPTableContext, chain, 1,
+		if err := s.ipt.Append(
+			appAckPacketIPTableContext, chain,
 			"-p", rules[i].Protocol, "-m", "state", "--state", "NEW",
 			"-d", rules[i].Address,
 			"--dport", rules[i].Port,
@@ -524,7 +524,7 @@ func (s *iptablesSupervisor) deleteAppACLs(chain string, ip string, rules []poli
 	for i := range rules {
 		if err := s.ipt.Delete(
 			appAckPacketIPTableContext, chain,
-			"-p", rules[i].Protocol,
+			"-p", rules[i].Protocol, "-m", "state", "--state", "NEW",
 			"-d", rules[i].Address,
 			"--dport", rules[i].Port,
 			"-j", "ACCEPT",
@@ -552,8 +552,8 @@ func (s *iptablesSupervisor) addNetACLs(chain, ip string, rules []policy.IPRule)
 
 	for i := range rules {
 
-		if err := s.ipt.Insert(
-			netPacketIPTableContext, chain, 1,
+		if err := s.ipt.Append(
+			netPacketIPTableContext, chain,
 			"-p", rules[i].Protocol,
 			"-s", rules[i].Address,
 			"--dport", rules[i].Port,

--- a/supervisor/iptables_test.go
+++ b/supervisor/iptables_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aporeto-inc/trireme/collector"
 	"github.com/aporeto-inc/trireme/enforcer"
+	"github.com/aporeto-inc/trireme/policy"
 	// "github.com/aporeto-inc/trireme/policy"
 	"github.com/coreos/go-iptables/iptables"
 )
@@ -51,7 +52,6 @@ func TestNewIPTables(t *testing.T) {
 
 }
 
-/*
 func TestSupervise(t *testing.T) {
 	_, err := iptables.New()
 	if err != nil {
@@ -60,8 +60,7 @@ func TestSupervise(t *testing.T) {
 	}
 	s := doNewIPTSupervisor(t)
 	containerInfo := policy.NewPUInfo("12345")
-
-	containerInfo.Runtime.SetIPAddresses(map[string]string{"bridge": "127.0.0.1"})
+	containerInfo.Runtime.SetIPAddresses(map[string]string{"bridge": "30.30.30.30"})
 
 	err = s.Supervise("12345", containerInfo)
 	if err != nil {
@@ -79,4 +78,3 @@ func TestSupervise(t *testing.T) {
 	}
 
 }
-*/

--- a/supervisor/iptablesprovider.go
+++ b/supervisor/iptablesprovider.go
@@ -1,0 +1,21 @@
+package supervisor
+
+import "github.com/coreos/go-iptables/iptables"
+
+// IptablesProvider is an abstraction of all the methods an implementation of userspace
+// iptables need to provide.
+type IptablesProvider interface {
+	Append(table, chain string, rulespec ...string) error
+	Insert(table, chain string, pos int, rulespec ...string) error
+	Delete(table, chain string, rulespec ...string) error
+	ListChains(table string) ([]string, error)
+	ClearChain(table, chain string) error
+	DeleteChain(table, chain string) error
+	NewChain(table, chain string) error
+}
+
+// NewGoIPTablesProvider returns an IptablesProvider interface based on the go-iptables
+// external package.
+func NewGoIPTablesProvider() (IptablesProvider, error) {
+	return iptables.New()
+}

--- a/supervisor/iptablesprovidermock.go
+++ b/supervisor/iptablesprovidermock.go
@@ -1,0 +1,1 @@
+package supervisor

--- a/supervisor/iptablesprovidermock.go
+++ b/supervisor/iptablesprovidermock.go
@@ -1,1 +1,156 @@
 package supervisor
+
+import (
+	"sync"
+	"testing"
+)
+
+type iptablesProviderMockedMethods struct {
+	appendMock      func(table, chain string, rulespec ...string) error
+	insertMock      func(table, chain string, pos int, rulespec ...string) error
+	deleteMock      func(table, chain string, rulespec ...string) error
+	listChainsMock  func(table string) ([]string, error)
+	clearChainMock  func(table, chain string) error
+	deleteChainMock func(table, chain string) error
+	newChainMock    func(table, chain string) error
+}
+
+// TestIptablesProvider is a test implementation for IptablesProvider
+type TestIptablesProvider interface {
+	IptablesProvider
+	MockAppend(t *testing.T, impl func(table, chain string, rulespec ...string) error)
+	MockInsert(t *testing.T, impl func(table, chain string, pos int, rulespec ...string) error)
+	MockDelete(t *testing.T, impl func(table, chain string, rulespec ...string) error)
+	MockListChains(t *testing.T, impl func(table string) ([]string, error))
+	MockClearChain(t *testing.T, impl func(table, chain string) error)
+	MockDeleteChain(t *testing.T, impl func(table, chain string) error)
+	MockNewChain(t *testing.T, impl func(table, chain string) error)
+}
+
+// A testIptablesProvider is an empty TransactionalManipulator that can be easily mocked.
+type testIptablesProvider struct {
+	mocks       map[*testing.T]*iptablesProviderMockedMethods
+	lock        *sync.Mutex
+	currentTest *testing.T
+}
+
+// NewTestIptablesProvider returns a new TestManipulator.
+func NewTestIptablesProvider() TestIptablesProvider {
+	return &testIptablesProvider{
+		lock:  &sync.Mutex{},
+		mocks: map[*testing.T]*iptablesProviderMockedMethods{},
+	}
+}
+
+func (m *testIptablesProvider) MockAppend(t *testing.T, impl func(table, chain string, rulespec ...string) error) {
+
+	m.currentMocks(t).appendMock = impl
+}
+
+func (m *testIptablesProvider) MockInsert(t *testing.T, impl func(table, chain string, pos int, rulespec ...string) error) {
+
+	m.currentMocks(t).insertMock = impl
+}
+
+func (m *testIptablesProvider) MockDelete(t *testing.T, impl func(table, chain string, rulespec ...string) error) {
+
+	m.currentMocks(t).deleteMock = impl
+}
+
+func (m *testIptablesProvider) MockListChains(t *testing.T, impl func(table string) ([]string, error)) {
+
+	m.currentMocks(t).listChainsMock = impl
+}
+
+func (m *testIptablesProvider) MockClearChain(t *testing.T, impl func(table, chain string) error) {
+
+	m.currentMocks(t).clearChainMock = impl
+}
+
+func (m *testIptablesProvider) MockDeleteChain(t *testing.T, impl func(table, chain string) error) {
+
+	m.currentMocks(t).deleteChainMock = impl
+}
+
+func (m *testIptablesProvider) MockNewChain(t *testing.T, impl func(table, chain string) error) {
+
+	m.currentMocks(t).newChainMock = impl
+}
+
+func (m *testIptablesProvider) Append(table, chain string, rulespec ...string) error {
+
+	if mock := m.currentMocks(m.currentTest); mock != nil && mock.appendMock != nil {
+		return mock.appendMock(table, chain, rulespec...)
+	}
+
+	return nil
+}
+
+func (m *testIptablesProvider) Insert(table, chain string, pos int, rulespec ...string) error {
+
+	if mock := m.currentMocks(m.currentTest); mock != nil && mock.insertMock != nil {
+		return mock.insertMock(table, chain, pos, rulespec...)
+	}
+
+	return nil
+}
+
+func (m *testIptablesProvider) Delete(table, chain string, rulespec ...string) error {
+
+	if mock := m.currentMocks(m.currentTest); mock != nil && mock.deleteMock != nil {
+		return mock.deleteMock(table, chain, rulespec...)
+	}
+
+	return nil
+}
+
+func (m *testIptablesProvider) ListChains(table string) ([]string, error) {
+
+	if mock := m.currentMocks(m.currentTest); mock != nil && mock.listChainsMock != nil {
+		return mock.listChainsMock(table)
+	}
+
+	return nil, nil
+}
+
+func (m *testIptablesProvider) ClearChain(table, chain string) error {
+
+	if mock := m.currentMocks(m.currentTest); mock != nil && mock.clearChainMock != nil {
+		return mock.clearChainMock(table, chain)
+	}
+
+	return nil
+}
+
+func (m *testIptablesProvider) DeleteChain(table, chain string) error {
+
+	if mock := m.currentMocks(m.currentTest); mock != nil && mock.deleteChainMock != nil {
+		return mock.deleteChainMock(table, chain)
+	}
+
+	return nil
+}
+
+func (m *testIptablesProvider) NewChain(table, chain string) error {
+
+	if mock := m.currentMocks(m.currentTest); mock != nil && mock.newChainMock != nil {
+		return mock.newChainMock(table, chain)
+	}
+
+	return nil
+}
+
+func (m *testIptablesProvider) currentMocks(t *testing.T) *iptablesProviderMockedMethods {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	mocks := m.mocks[t]
+
+	if mocks == nil {
+		mocks = &iptablesProviderMockedMethods{}
+		m.mocks[t] = mocks
+	}
+
+	m.currentTest = t
+	return mocks
+}

--- a/supervisor/supervisormock.go
+++ b/supervisor/supervisormock.go
@@ -22,7 +22,7 @@ type mockedMethods struct {
 	stopMock func() error
 }
 
-// TestSupervisor us
+// TestSupervisor is a test implementation for IptablesProvider
 type TestSupervisor interface {
 	Supervisor
 	MockSupervise(t *testing.T, impl func(contextID string, puInfo *policy.PUInfo) error)


### PR DESCRIPTION
Changes the logic: 
All Trireme subnets are always going to NFQueue. All other subnets come logically after those.