### PR TITLE
fixed: reduce all log level from info to debug, as per Aporeto convention

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -162,7 +162,7 @@ func (c *Cache) Get(u interface{}) (i interface{}, err error) {
 
 	if _, ok := c.data[u]; !ok {
 
-		return nil, fmt.Errorf("Item does not exist.")
+		return nil, fmt.Errorf("Item does not exist")
 	}
 
 	return c.data[u].value, nil

--- a/enforcer/datapath.go
+++ b/enforcer/datapath.go
@@ -261,7 +261,7 @@ func (d *datapathEnforcer) Start() error {
 
 	log.WithFields(log.Fields{
 		"package": "enforcer",
-	}).Info("Start enforcer")
+	}).Debug("Start enforcer")
 
 	d.StartApplicationInterceptor()
 	d.StartNetworkInterceptor()
@@ -273,7 +273,7 @@ func (d *datapathEnforcer) Start() error {
 func (d *datapathEnforcer) Stop() error {
 	log.WithFields(log.Fields{
 		"package": "enforcer",
-	}).Info("Stop enforcer")
+	}).Debug("Stop enforcer")
 	return nil
 }
 
@@ -282,7 +282,7 @@ func (d *datapathEnforcer) Stop() error {
 func (d *datapathEnforcer) StartApplicationInterceptor() {
 	log.WithFields(log.Fields{
 		"package": "enforcer",
-	}).Info("Start application interceptor")
+	}).Debug("Start application interceptor")
 
 	var err error
 

--- a/enforcer/tokens/pkisecrets.go
+++ b/enforcer/tokens/pkisecrets.go
@@ -117,7 +117,7 @@ func (p *PKISecrets) PublicKeyAdd(host string, newCert []byte) error {
 	log.WithFields(log.Fields{
 		"package": "tokens",
 		"host":    host,
-	}).Info("Adding Cert for host")
+	}).Debug("Adding Cert for host")
 
 	p.CertificateCache[host] = cert.PublicKey.(*ecdsa.PublicKey)
 	return nil

--- a/monitor/docker.go
+++ b/monitor/docker.go
@@ -198,7 +198,7 @@ func (d *dockerMonitor) Start() error {
 
 	log.WithFields(log.Fields{
 		"package": "monitor",
-	}).Info("Starting the docker monitor")
+	}).Debug("Starting the docker monitor")
 
 	// Starting the eventListener First.
 	go d.eventListener()
@@ -226,7 +226,7 @@ func (d *dockerMonitor) Stop() error {
 
 	log.WithFields(log.Fields{
 		"package": "monitor",
-	}).Info("Stopping the docker monitor")
+	}).Debug("Stopping the docker monitor")
 
 	d.stoplistener <- true
 	d.stopprocessor <- true
@@ -287,7 +287,7 @@ func (d *dockerMonitor) eventListener() {
 				log.WithFields(log.Fields{
 					"package": "monitor",
 					"error":   err.Error(),
-				}).Info("Received docker event error")
+				}).Debug("Received docker event error")
 			}
 		case stop := <-d.stoplistener:
 			if stop {
@@ -303,7 +303,7 @@ func (d *dockerMonitor) syncContainers() error {
 
 	log.WithFields(log.Fields{
 		"package": "monitor",
-	}).Info("Syncing all existing containers")
+	}).Debug("Syncing all existing containers")
 
 	options := types.ContainerListOptions{All: true}
 	containers, err := d.dockerClient.ContainerList(context.Background(), options)
@@ -380,7 +380,7 @@ func (d *dockerMonitor) startDockerContainer(dockerInfo *types.ContainerJSON) er
 		log.WithFields(log.Fields{
 			"package":   "monitor",
 			"contextID": contextID,
-		}).Info("IP Not present in container, Attempting activation")
+		}).Debug("IP Not present in container, Attempting activation")
 
 		ip = ""
 	}
@@ -409,7 +409,7 @@ func (d *dockerMonitor) stopDockerContainer(dockerID string) error {
 	log.WithFields(log.Fields{
 		"package":  "monitor",
 		"dockerID": dockerID,
-	}).Info("Monitor removed docker container")
+	}).Debug("Monitor removed docker container")
 
 	contextID, err := contextIDFromDockerID(dockerID)
 
@@ -435,7 +435,7 @@ func (d *dockerMonitor) extractMetadata(dockerInfo *types.ContainerJSON) (*polic
 			"package": "monitor",
 		}).Debug("DockerInfo is empty when exacting the metadata")
 
-		return nil, fmt.Errorf("DockerInfo is empty.")
+		return nil, fmt.Errorf("DockerInfo is empty")
 	}
 
 	if d.metadataExtractor != nil {

--- a/supervisor/ipsetsupervisor.go
+++ b/supervisor/ipsetsupervisor.go
@@ -84,7 +84,7 @@ func (s *ipsetSupervisor) Supervise(contextID string, containerInfo *policy.PUIn
 	log.WithFields(log.Fields{
 		"package":   "supervisor",
 		"contextID": contextID,
-	}).Info("Supervise PU")
+	}).Debug("Supervise PU")
 
 	if containerInfo == nil || containerInfo.Policy == nil || containerInfo.Runtime == nil {
 		log.WithFields(log.Fields{
@@ -104,7 +104,7 @@ func (s *ipsetSupervisor) Supervise(contextID string, containerInfo *policy.PUIn
 	log.WithFields(log.Fields{
 		"package":   "supervisor",
 		"contextID": contextID,
-	}).Info("PU ContextID Already exist in Cache. Updating.")
+	}).Debug("PU ContextID Already exist in Cache. Updating.")
 
 	return s.doUpdatePU(contextID, containerInfo)
 }
@@ -114,7 +114,7 @@ func (s *ipsetSupervisor) Unsupervise(contextID string) error {
 	log.WithFields(log.Fields{
 		"package":   "supervisor",
 		"contextID": contextID,
-	}).Info("Unsupervise PU")
+	}).Debug("Unsupervise PU")
 
 	result, err := s.versionTracker.Get(contextID)
 
@@ -226,7 +226,7 @@ func (s *ipsetSupervisor) doCreatePU(contextID string, containerInfo *policy.PUI
 	log.WithFields(log.Fields{
 		"package":   "supervisor",
 		"contextID": contextID,
-	}).Info("PU Creation")
+	}).Debug("PU Creation")
 
 	index := 0
 
@@ -277,7 +277,7 @@ func (s *ipsetSupervisor) doUpdatePU(contextID string, containerInfo *policy.PUI
 	log.WithFields(log.Fields{
 		"package":   "supervisor",
 		"contextID": contextID,
-	}).Info("PU Supervisor Update")
+	}).Debug("PU Supervisor Update")
 
 	cacheEntry, err := s.versionTracker.LockedModify(contextID, add, 1)
 
@@ -339,7 +339,7 @@ func (s *ipsetSupervisor) createInitialIPSet() error {
 func (s *ipsetSupervisor) cleanACLs() error {
 	log.WithFields(log.Fields{
 		"package": "supervisor",
-	}).Info("Cleaning all IPTables")
+	}).Debug("Cleaning all IPTables")
 
 	// Clean Application Rules/Chains
 	s.ipu.CleanACLs()

--- a/supervisor/iptablessupervisor.go
+++ b/supervisor/iptablessupervisor.go
@@ -102,7 +102,7 @@ func (s *iptablesSupervisor) Supervise(contextID string, containerInfo *policy.P
 	log.WithFields(log.Fields{
 		"package":   "supervisor",
 		"contextID": contextID,
-	}).Info("Supervise PU")
+	}).Debug("Supervise PU")
 
 	if containerInfo == nil || containerInfo.Policy == nil || containerInfo.Runtime == nil {
 		log.WithFields(log.Fields{
@@ -129,7 +129,7 @@ func (s *iptablesSupervisor) Unsupervise(contextID string) error {
 	log.WithFields(log.Fields{
 		"package":   "supervisor",
 		"contextID": contextID,
-	}).Info("Unsupervise the given contextID, clean the iptable rules")
+	}).Debug("Unsupervise the given contextID, clean the iptable rules")
 
 	result, err := s.versionTracker.Get(contextID)
 
@@ -139,7 +139,7 @@ func (s *iptablesSupervisor) Unsupervise(contextID string) error {
 			"contextID": contextID,
 		}).Debug("Cannot find policy version")
 
-		return fmt.Errorf("Cannot find policy version!")
+		return fmt.Errorf("Cannot find policy version")
 	}
 
 	cacheEntry := result.(*supervisorCacheEntry)
@@ -178,7 +178,7 @@ func (s *iptablesSupervisor) Unsupervise(contextID string) error {
 func (s *iptablesSupervisor) Start() error {
 	log.WithFields(log.Fields{
 		"package": "supervisor",
-	}).Info("Start the supervisor")
+	}).Debug("Start the supervisor")
 
 	if s.ipu.FilterMarkedPackets(s.Mark) != nil {
 		log.WithFields(log.Fields{
@@ -195,7 +195,7 @@ func (s *iptablesSupervisor) Start() error {
 func (s *iptablesSupervisor) Stop() error {
 	log.WithFields(log.Fields{
 		"package": "supervisor",
-	}).Info("Stop the supervisor")
+	}).Debug("Stop the supervisor")
 
 	// Clean any previous ACLs that we have installed
 	s.CleanACL()
@@ -207,7 +207,7 @@ func (s *iptablesSupervisor) doCreatePU(contextID string, containerInfo *policy.
 	log.WithFields(log.Fields{
 		"package":   "supervisor",
 		"contextID": contextID,
-	}).Info("IPTables update for the creation of a pu")
+	}).Debug("IPTables update for the creation of a pu")
 
 	index := 0
 
@@ -327,7 +327,7 @@ func (s *iptablesSupervisor) doUpdatePU(contextID string, containerInfo *policy.
 	log.WithFields(log.Fields{
 		"package":   "supervisor",
 		"contextID": contextID,
-	}).Info("IPTables update for the update of a pu")
+	}).Debug("IPTables update for the update of a pu")
 
 	cacheEntry, err := s.versionTracker.LockedModify(contextID, add, 1)
 
@@ -478,7 +478,7 @@ func (s *iptablesSupervisor) CleanACL() {
 
 	log.WithFields(log.Fields{
 		"package": "supervisor",
-	}).Info("Clean all ACL")
+	}).Debug("Clean all ACL")
 
 	// Clean Application Rules/Chains
 	s.ipu.CleanACLs()

--- a/supervisor/iptablesutils/iptablesutils.go
+++ b/supervisor/iptablesutils/iptablesutils.go
@@ -184,7 +184,7 @@ func (r *ipTableUtils) trapRules(appChain string, netChain string, network strin
 func (r *ipTableUtils) CleanACLs() error {
 	log.WithFields(log.Fields{
 		"package": "iptablesutils",
-	}).Info("Cleaning all IPTables")
+	}).Debug("Cleaning all IPTables")
 
 	// Clean Application Rules/Chains
 	r.cleanACLSection(appPacketIPTableContext, appPacketIPTableSection, chainPrefix)
@@ -224,7 +224,7 @@ func (r *ipTableUtils) AddContainerChain(appChain string, netChain string) error
 		"package":  "iptablesutils",
 		"appChain": appChain,
 		"netChain": netChain,
-	}).Info("Add a container chain")
+	}).Debug("Add a container chain")
 
 	if err := r.ipt.NewChain(appPacketIPTableContext, appChain); err != nil {
 		log.WithFields(log.Fields{
@@ -273,7 +273,7 @@ func (r *ipTableUtils) deleteChain(context, chain string) error {
 		"package": "iptablesutils",
 		"context": context,
 		"chain":   chain,
-	}).Info("Delete a chain")
+	}).Debug("Delete a chain")
 
 	if err := r.ipt.ClearChain(context, chain); err != nil {
 		log.WithFields(log.Fields{
@@ -305,7 +305,7 @@ func (r *ipTableUtils) DeleteAllContainerChains(appChain, netChain string) error
 		"package":  "iptablesutils",
 		"appChain": appChain,
 		"netChain": netChain,
-	}).Info("Delete all container chains")
+	}).Debug("Delete all container chains")
 
 	if err := r.deleteChain(appPacketIPTableContext, appChain); err != nil {
 		log.WithFields(log.Fields{
@@ -350,7 +350,7 @@ func (r *ipTableUtils) AddChainRules(appChain string, netChain string, ip string
 		"appChain": appChain,
 		"netChain": netChain,
 		"ip":       ip,
-	}).Info("Add chain rules")
+	}).Debug("Add chain rules")
 
 	ChainRules := r.chainRules(appChain, netChain, ip)
 	for _, cr := range ChainRules {
@@ -378,7 +378,7 @@ func (r *ipTableUtils) DeleteChainRules(appChain, netChain, ip string) error {
 		"appChain": appChain,
 		"netChain": netChain,
 		"ip":       ip,
-	}).Info("Delete chain rules")
+	}).Debug("Delete chain rules")
 
 	ChainRules := r.chainRules(appChain, netChain, ip)
 	for _, cr := range ChainRules {
@@ -407,7 +407,7 @@ func (r *ipTableUtils) AddPacketTrap(appChain string, netChain string, ip string
 		"appChain": appChain,
 		"netChain": netChain,
 		"ip":       ip,
-	}).Info("Add Packet trap")
+	}).Debug("Add Packet trap")
 
 	for _, network := range targetNetworks {
 
@@ -438,7 +438,7 @@ func (r *ipTableUtils) DeletePacketTrap(appChain string, netChain string, ip str
 		"appChain": appChain,
 		"netChain": netChain,
 		"ip":       ip,
-	}).Info("Delete Packet trap")
+	}).Debug("Delete Packet trap")
 
 	for _, network := range targetNetworks {
 
@@ -469,7 +469,7 @@ func (r *ipTableUtils) AddAppACLs(chain string, ip string, rules []policy.IPRule
 		"package": "iptablesutils",
 		"ip":      ip,
 		"chain":   chain,
-	}).Info("Add App ACLs")
+	}).Debug("Add App ACLs")
 
 	for i := range rules {
 
@@ -518,7 +518,7 @@ func (r *ipTableUtils) DeleteAppACLs(chain string, ip string, rules []policy.IPR
 		"ip":      ip,
 		"rules":   rules,
 		"chain":   chain,
-	}).Info("Delete App ACLs")
+	}).Debug("Delete App ACLs")
 
 	for i := range rules {
 		if err := r.ipt.Delete(
@@ -565,7 +565,7 @@ func (r *ipTableUtils) AddNetACLs(chain, ip string, rules []policy.IPRule) error
 		"ip":      ip,
 		"rules":   rules,
 		"chain":   chain,
-	}).Info("Add Net ACLs")
+	}).Debug("Add Net ACLs")
 
 	for i := range rules {
 
@@ -615,7 +615,7 @@ func (r *ipTableUtils) DeleteNetACLs(chain string, ip string, rules []policy.IPR
 		"ip":      ip,
 		"rules":   rules,
 		"chain":   chain,
-	}).Info("Delete Net ACLs")
+	}).Debug("Delete Net ACLs")
 
 	for i := range rules {
 		if err := r.ipt.Delete(
@@ -660,7 +660,7 @@ func (r *ipTableUtils) cleanACLSection(context, section, chainPrefix string) {
 		"context":     context,
 		"section":     section,
 		"chainPrefix": chainPrefix,
-	}).Info("Clean ACL section")
+	}).Debug("Clean ACL section")
 
 	if err := r.ipt.ClearChain(context, section); err != nil {
 		log.WithFields(log.Fields{
@@ -806,7 +806,7 @@ func (r *ipTableUtils) AddAppSetRule(set string, ip string) error {
 		"package": "iptablesutils",
 		"ip":      ip,
 		"set":     set,
-	}).Info("Add App ACLs")
+	}).Debug("Add App ACLs")
 
 	if err := r.ipt.Insert(
 		appAckPacketIPTableContext, appPacketIPTableSection, 3,
@@ -833,7 +833,7 @@ func (r *ipTableUtils) DeleteAppSetRule(set string, ip string) error {
 	log.WithFields(log.Fields{
 		"package": "iptablesutils",
 		"ip":      ip,
-	}).Info("Delete App ACLs")
+	}).Debug("Delete App ACLs")
 
 	if err := r.ipt.Delete(
 		appAckPacketIPTableContext, appPacketIPTableSection,
@@ -861,7 +861,7 @@ func (r *ipTableUtils) AddNetSetRule(set string, ip string) error {
 		"package": "iptablesutils",
 		"ip":      ip,
 		"set":     set,
-	}).Info("Add App ACLs")
+	}).Debug("Add App ACLs")
 
 	if err := r.ipt.Insert(
 		netPacketIPTableContext, netPacketIPTableSection, 2,
@@ -886,7 +886,7 @@ func (r *ipTableUtils) DeleteNetSetRule(set string, ip string) error {
 	log.WithFields(log.Fields{
 		"package": "iptablesutils",
 		"ip":      ip,
-	}).Info("Delete App ACLs")
+	}).Debug("Delete App ACLs")
 
 	if err := r.ipt.Delete(
 		netPacketIPTableContext, netPacketIPTableSection,

--- a/trireme.go
+++ b/trireme.go
@@ -196,7 +196,7 @@ func (t *trireme) doHandleCreate(contextID string) error {
 			"runtimeInfo": runtimeInfo,
 			"error":       err.Error(),
 		}).Debug("Error returned when resolving the context")
-		return fmt.Errorf("Policy Error for this context: %s . Container killed. %s", contextID, err)
+		return fmt.Errorf("Policy Error for this context: %s. Container killed. %s", contextID, err)
 	}
 
 	if policyInfo == nil {
@@ -206,7 +206,8 @@ func (t *trireme) doHandleCreate(contextID string) error {
 			"runtimeInfo": runtimeInfo,
 			"error":       err.Error(),
 		}).Debug("Nil policy returned when resolving the context")
-		return fmt.Errorf("Nil policy returned for context: %s. Container killed.", contextID)
+
+		return fmt.Errorf("Nil policy returned for context: %s. Container killed", contextID)
 	}
 
 	present, err := isPolicyIPValid(policyInfo)
@@ -215,8 +216,7 @@ func (t *trireme) doHandleCreate(contextID string) error {
 		log.WithFields(log.Fields{
 			"package":   "trireme",
 			"contextID": contextID,
-		}).Info("No IP given in the policy, not activating")
-
+		}).Warn("No IP given in the policy, not activating")
 		return nil
 	}
 
@@ -411,7 +411,7 @@ func (t *trireme) run() {
 		case <-t.stop:
 			log.WithFields(log.Fields{
 				"package": "trireme",
-			}).Info("Stopping trireme worker.")
+			}).Debug("Stopping trireme worker.")
 			return
 		case req := <-t.requests:
 			log.WithFields(log.Fields{


### PR DESCRIPTION
Aporeto's convention is to have all libraries to use debug level for informative messages. This patch aligns Trireme with our internal convention.
