### PR TITLE
NEW: RPC Server monitor 

### DIFF
--- a/monitor/rpc.go
+++ b/monitor/rpc.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/rpc"
 	"net/rpc/jsonrpc"
+	"strconv"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -14,7 +15,30 @@ import (
 
 // RPCMetadataExtractor is a function used to extract a *policy.PURuntime from a given
 // EventInfo.
-type RPCMetadataExtractor func(EventInfo) (*policy.PURuntime, error)
+type RPCMetadataExtractor func(*EventInfo) (*policy.PURuntime, error)
+
+func defaultRPCMetadataExtractor(event *EventInfo) (*policy.PURuntime, error) {
+	if event.Name == "" {
+		return nil, fmt.Errorf("EventInfo PU Name is empty")
+	}
+
+	if event.PID == "" {
+		return nil, fmt.Errorf("EventInfo PID is empty")
+	}
+
+	if event.PUID == "" {
+		return nil, fmt.Errorf("EventInfo PUID is empty")
+	}
+
+	runtimeTags := policy.NewTagsMap(event.Tags)
+	runtimeIps := policy.NewIPMap(event.IPs)
+	runtimePID, err := strconv.Atoi(event.PID)
+	if err != nil {
+		return nil, fmt.Errorf("PID is invalid: %s", err)
+	}
+
+	return policy.NewPURuntime(event.Name, runtimePID, runtimeTags, runtimeIps), nil
+}
 
 // A RPCEventHandler is type of docker event handler functions.
 type RPCEventHandler func(*EventInfo) error
@@ -35,13 +59,25 @@ type Server struct {
 }
 
 // NewRPCMonitor returns a fully initialized RPC Based monitor.
-func NewRPCMonitor(rpcAddress string, metadataExtractor RPCMetadataExtractor, puHandler ProcessingUnitsHandler, collector collector.EventCollector) Monitor {
+func NewRPCMonitor(rpcAddress string, metadataExtractor RPCMetadataExtractor, puHandler ProcessingUnitsHandler, collector collector.EventCollector) (Monitor, error) {
+
+	if rpcAddress == "" {
+		return nil, fmt.Errorf("RPC endpoint address invalid")
+	}
+
+	if puHandler == nil {
+		return nil, fmt.Errorf("PU Handler required")
+	}
 
 	monitorServer := &Server{
 		collector:         collector,
 		puHandler:         puHandler,
 		metadataExtractor: metadataExtractor,
 		handlers:          map[Event]RPCEventHandler{},
+	}
+
+	if metadataExtractor == nil {
+		monitorServer.metadataExtractor = defaultRPCMetadataExtractor
 	}
 
 	monitorServer.addHandler(EventStart, monitorServer.handleStartEvent)
@@ -55,30 +91,44 @@ func NewRPCMonitor(rpcAddress string, metadataExtractor RPCMetadataExtractor, pu
 		monitorServer: monitorServer,
 	}
 
+	// Registering the monitorRPCServer as an RPC Server.
 	r.rpcServer = rpc.NewServer()
 	err := r.rpcServer.Register(r.monitorServer)
 	if err != nil {
 		log.Fatalf("Format of service MonitorServer isn't correct. %s", err)
 	}
 
-	return r
+	return r, nil
 }
 
 // Start starts the RPC monitoring.
+// Blocking, so needs to be started with go...
 func (r *rpcMonitor) Start() error {
 	listener, err := net.Listen("unix", r.rpcAddress)
 	if err != nil {
-		log.Fatal("listen error:", err)
+		return fmt.Errorf("couldn't create binding: %s", err)
 	}
+	defer listener.Close()
+
+	log.WithFields(log.Fields{
+		"package": "monitor",
+	}).Debugf("Starting RPC Server and listening at endpoint: %s", r.rpcAddress)
 
 	for {
-		fmt.Println("Handling new request")
+		log.WithFields(log.Fields{
+			"package": "monitor",
+		}).Debugf("Handling new RPC Monitor request")
+
 		conn, err := listener.Accept()
+
 		if err != nil {
-			log.Fatal(err)
+			log.WithFields(log.Fields{
+				"package": "monitor",
+				"error":   err.Error(),
+			}).Error("Error while handling RPC event")
 		}
 
-		go r.rpcServer.ServeCodec(jsonrpc.NewServerCodec(conn))
+		r.rpcServer.ServeCodec(jsonrpc.NewServerCodec(conn))
 	}
 }
 
@@ -93,13 +143,10 @@ func (s *Server) addHandler(event Event, handler RPCEventHandler) {
 
 // HandleEvent Gets called when clients generate events.
 func (s *Server) HandleEvent(eventInfo *EventInfo, result *RPCResponse) error {
-	fmt.Printf("Received an event of type: %+v ", eventInfo.EventType)
+	log.Debugf("Handling RPC eventof type %s", eventInfo.EventType)
 
 	f, present := s.handlers[eventInfo.EventType]
 	if present {
-		log.WithFields(log.Fields{
-			"package": "monitor",
-		}).Debug("Handling RPC event")
 
 		err := f(eventInfo)
 
@@ -110,23 +157,27 @@ func (s *Server) HandleEvent(eventInfo *EventInfo, result *RPCResponse) error {
 			}).Error("Error while handling event")
 		}
 	} else {
-		log.WithFields(log.Fields{
-			"package": "monitor",
-		}).Debug("RPC event not handled.")
+		log.Debugf("RPC event not handled.")
 	}
 
 	return nil
 }
 
 func generateContextID(eventInfo *EventInfo) (string, error) {
+	if eventInfo.PUID == "" {
+		return "", fmt.Errorf("PUID is empty from eventInfo")
+	}
 	return eventInfo.PUID, nil
 }
 
 func (s *Server) handleCreateEvent(eventInfo *EventInfo) error {
 	contextID, err := generateContextID(eventInfo)
 	if err != nil {
-		return fmt.Errorf("Couldn't generate a contextID")
+		return fmt.Errorf("Couldn't generate a contextID: %s", err)
 	}
+
+	// TODO: Adapt to generic PU
+	s.collector.CollectContainerEvent(contextID, "", nil, collector.ContainerCreate)
 
 	// Send the event upstream
 	errChan := s.puHandler.HandlePUEvent(contextID, EventCreate)
@@ -136,8 +187,19 @@ func (s *Server) handleCreateEvent(eventInfo *EventInfo) error {
 func (s *Server) handleStartEvent(eventInfo *EventInfo) error {
 	contextID, err := generateContextID(eventInfo)
 	if err != nil {
-		return fmt.Errorf("Couldn't generate a contextID")
+		return fmt.Errorf("Couldn't generate a contextID: %s", err)
 	}
+
+	runtimeInfo, err := s.metadataExtractor(eventInfo)
+	if err != nil {
+		return fmt.Errorf("Couldn't generate RuntimeInfo: %s", err)
+	}
+
+	s.puHandler.SetPURuntime(contextID, runtimeInfo)
+
+	defaultIP, _ := runtimeInfo.DefaultIPAddress()
+
+	s.collector.CollectContainerEvent(contextID, defaultIP, runtimeInfo.Tags(), collector.ContainerStart)
 
 	// Send the event upstream
 	errChan := s.puHandler.HandlePUEvent(contextID, EventStart)
@@ -147,7 +209,7 @@ func (s *Server) handleStartEvent(eventInfo *EventInfo) error {
 func (s *Server) handleStopEvent(eventInfo *EventInfo) error {
 	contextID, err := generateContextID(eventInfo)
 	if err != nil {
-		return fmt.Errorf("Couldn't generate a contextID")
+		return fmt.Errorf("Couldn't generate a contextID: %s", err)
 	}
 
 	// Send the event upstream
@@ -158,7 +220,7 @@ func (s *Server) handleStopEvent(eventInfo *EventInfo) error {
 func (s *Server) handleDestroyEvent(eventInfo *EventInfo) error {
 	contextID, err := generateContextID(eventInfo)
 	if err != nil {
-		return fmt.Errorf("Couldn't generate a contextID")
+		return fmt.Errorf("Couldn't generate a contextID: %s", err)
 	}
 
 	// Send the event upstream
@@ -169,7 +231,7 @@ func (s *Server) handleDestroyEvent(eventInfo *EventInfo) error {
 func (s *Server) handlePauseEvent(eventInfo *EventInfo) error {
 	contextID, err := generateContextID(eventInfo)
 	if err != nil {
-		return fmt.Errorf("Couldn't generate a contextID")
+		return fmt.Errorf("Couldn't generate a contextID: %s", err)
 	}
 
 	errChan := s.puHandler.HandlePUEvent(contextID, EventPause)

--- a/monitor/rpc.go
+++ b/monitor/rpc.go
@@ -1,0 +1,47 @@
+package monitor
+
+import (
+	"github.com/aporeto-inc/trireme/collector"
+	"github.com/aporeto-inc/trireme/policy"
+	"github.com/docker/docker/api/types/events"
+)
+
+// A RPCMetadataExtractor is a function used to extract a *policy.PURuntime from a given
+// docker ContainerJSON.
+type RPCMetadataExtractor func() (*policy.PURuntime, error)
+
+// rpcMonitor implements the RPC connection monitoring
+type rpcMonitor struct {
+	metadataExtractor  RPCMetadataExtractor
+	handlers           map[DockerEvent]func(event *events.Message) error
+	eventnotifications chan *events.Message
+	stopprocessor      chan bool
+	stoplistener       chan bool
+	syncAtStart        bool
+
+	puHandler ProcessingUnitsHandler
+}
+
+// NewRPCMonitor is a
+func NewRPCMonitor(
+	socketType string,
+	socketAddress string,
+	p ProcessingUnitsHandler,
+	m RPCMetadataExtractor,
+	l collector.EventCollector, syncAtStart bool,
+) Monitor {
+
+	r := &rpcMonitor{}
+
+	return r
+}
+
+// Start starts the RPC monitoring.
+func (r *rpcMonitor) Start() error {
+	return nil
+}
+
+// Stop monitoring RPC events.
+func (r *rpcMonitor) Stop() error {
+	return nil
+}

--- a/monitor/rpc.go
+++ b/monitor/rpc.go
@@ -1,9 +1,14 @@
 package monitor
 
 import (
+	"fmt"
+	"log"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+
 	"github.com/aporeto-inc/trireme/collector"
 	"github.com/aporeto-inc/trireme/policy"
-	"github.com/docker/docker/api/types/events"
 )
 
 // A RPCMetadataExtractor is a function used to extract a *policy.PURuntime from a given
@@ -12,36 +17,68 @@ type RPCMetadataExtractor func() (*policy.PURuntime, error)
 
 // rpcMonitor implements the RPC connection monitoring
 type rpcMonitor struct {
-	metadataExtractor  RPCMetadataExtractor
-	handlers           map[DockerEvent]func(event *events.Message) error
-	eventnotifications chan *events.Message
-	stopprocessor      chan bool
-	stoplistener       chan bool
-	syncAtStart        bool
-
-	puHandler ProcessingUnitsHandler
+	rpcAddress    string
+	rpcServer     *rpc.Server
+	monitorServer *Server
 }
 
-// NewRPCMonitor is a
-func NewRPCMonitor(
-	socketType string,
-	socketAddress string,
-	p ProcessingUnitsHandler,
-	m RPCMetadataExtractor,
-	l collector.EventCollector, syncAtStart bool,
-) Monitor {
+// Server represents the RPC server implementation
+type Server struct {
+	handlers          map[Event]func(EventInfo *EventInfo) error
+	metadataExtractor RPCMetadataExtractor
+	collector         collector.EventCollector
+	puHandler         ProcessingUnitsHandler
+}
 
-	r := &rpcMonitor{}
+// NewRPCMonitor returns a fully initialized RPC Based monitor.
+func NewRPCMonitor(rpcAddress string, metadataExtractor RPCMetadataExtractor, puHandler ProcessingUnitsHandler, collector collector.EventCollector) Monitor {
+
+	monitorServer := &Server{
+		collector:         collector,
+		puHandler:         puHandler,
+		metadataExtractor: metadataExtractor,
+	}
+
+	r := &rpcMonitor{
+		rpcAddress:    rpcAddress,
+		monitorServer: monitorServer,
+	}
+
+	r.rpcServer = rpc.NewServer()
+	err := r.rpcServer.Register(r.monitorServer)
+
+	if err != nil {
+		log.Fatalf("Format of service MonitorServer isn't correct. %s", err)
+	}
 
 	return r
 }
 
 // Start starts the RPC monitoring.
 func (r *rpcMonitor) Start() error {
-	return nil
+	listener, e := net.Listen("unix", r.rpcAddress)
+	if e != nil {
+		log.Fatal("listen error:", e)
+	}
+
+	for {
+		fmt.Println("Handling new request")
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		go r.rpcServer.ServeCodec(jsonrpc.NewServerCodec(conn))
+	}
 }
 
 // Stop monitoring RPC events.
 func (r *rpcMonitor) Stop() error {
+	return nil
+}
+
+// HandleEvent Gets called on Events
+func (r *Server) HandleEvent(eventInfo *EventInfo, result *RPCResponse) error {
+	fmt.Printf("Received an event: %+v ", eventInfo)
 	return nil
 }

--- a/monitor/rpc.go
+++ b/monitor/rpc.go
@@ -2,29 +2,33 @@ package monitor
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"net/rpc"
 	"net/rpc/jsonrpc"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/aporeto-inc/trireme/collector"
 	"github.com/aporeto-inc/trireme/policy"
 )
 
-// A RPCMetadataExtractor is a function used to extract a *policy.PURuntime from a given
-// docker ContainerJSON.
-type RPCMetadataExtractor func() (*policy.PURuntime, error)
+// RPCMetadataExtractor is a function used to extract a *policy.PURuntime from a given
+// EventInfo.
+type RPCMetadataExtractor func(EventInfo) (*policy.PURuntime, error)
 
-// rpcMonitor implements the RPC connection monitoring
+// A RPCEventHandler is type of docker event handler functions.
+type RPCEventHandler func(*EventInfo) error
+
+// rpcMonitor implements the RPC connection
 type rpcMonitor struct {
 	rpcAddress    string
 	rpcServer     *rpc.Server
 	monitorServer *Server
 }
 
-// Server represents the RPC server implementation
+// Server represents the Monitor RPC Server implementation
 type Server struct {
-	handlers          map[Event]func(EventInfo *EventInfo) error
+	handlers          map[Event]RPCEventHandler
 	metadataExtractor RPCMetadataExtractor
 	collector         collector.EventCollector
 	puHandler         ProcessingUnitsHandler
@@ -37,7 +41,14 @@ func NewRPCMonitor(rpcAddress string, metadataExtractor RPCMetadataExtractor, pu
 		collector:         collector,
 		puHandler:         puHandler,
 		metadataExtractor: metadataExtractor,
+		handlers:          map[Event]RPCEventHandler{},
 	}
+
+	monitorServer.addHandler(EventStart, monitorServer.handleStartEvent)
+	monitorServer.addHandler(EventStop, monitorServer.handleStopEvent)
+	monitorServer.addHandler(EventCreate, monitorServer.handleCreateEvent)
+	monitorServer.addHandler(EventDestroy, monitorServer.handleDestroyEvent)
+	monitorServer.addHandler(EventPause, monitorServer.handlePauseEvent)
 
 	r := &rpcMonitor{
 		rpcAddress:    rpcAddress,
@@ -46,7 +57,6 @@ func NewRPCMonitor(rpcAddress string, metadataExtractor RPCMetadataExtractor, pu
 
 	r.rpcServer = rpc.NewServer()
 	err := r.rpcServer.Register(r.monitorServer)
-
 	if err != nil {
 		log.Fatalf("Format of service MonitorServer isn't correct. %s", err)
 	}
@@ -56,9 +66,9 @@ func NewRPCMonitor(rpcAddress string, metadataExtractor RPCMetadataExtractor, pu
 
 // Start starts the RPC monitoring.
 func (r *rpcMonitor) Start() error {
-	listener, e := net.Listen("unix", r.rpcAddress)
-	if e != nil {
-		log.Fatal("listen error:", e)
+	listener, err := net.Listen("unix", r.rpcAddress)
+	if err != nil {
+		log.Fatal("listen error:", err)
 	}
 
 	for {
@@ -77,8 +87,91 @@ func (r *rpcMonitor) Stop() error {
 	return nil
 }
 
-// HandleEvent Gets called on Events
-func (r *Server) HandleEvent(eventInfo *EventInfo, result *RPCResponse) error {
-	fmt.Printf("Received an event: %+v ", eventInfo)
+func (s *Server) addHandler(event Event, handler RPCEventHandler) {
+	s.handlers[event] = handler
+}
+
+// HandleEvent Gets called when clients generate events.
+func (s *Server) HandleEvent(eventInfo *EventInfo, result *RPCResponse) error {
+	fmt.Printf("Received an event of type: %+v ", eventInfo.EventType)
+
+	f, present := s.handlers[eventInfo.EventType]
+	if present {
+		log.WithFields(log.Fields{
+			"package": "monitor",
+		}).Debug("Handling RPC event")
+
+		err := f(eventInfo)
+
+		if err != nil {
+			log.WithFields(log.Fields{
+				"package": "monitor",
+				"error":   err.Error(),
+			}).Error("Error while handling event")
+		}
+	} else {
+		log.WithFields(log.Fields{
+			"package": "monitor",
+		}).Debug("RPC event not handled.")
+	}
+
 	return nil
+}
+
+func generateContextID(eventInfo *EventInfo) (string, error) {
+	return eventInfo.PUID, nil
+}
+
+func (s *Server) handleCreateEvent(eventInfo *EventInfo) error {
+	contextID, err := generateContextID(eventInfo)
+	if err != nil {
+		return fmt.Errorf("Couldn't generate a contextID")
+	}
+
+	// Send the event upstream
+	errChan := s.puHandler.HandlePUEvent(contextID, EventCreate)
+	return <-errChan
+}
+
+func (s *Server) handleStartEvent(eventInfo *EventInfo) error {
+	contextID, err := generateContextID(eventInfo)
+	if err != nil {
+		return fmt.Errorf("Couldn't generate a contextID")
+	}
+
+	// Send the event upstream
+	errChan := s.puHandler.HandlePUEvent(contextID, EventStart)
+	return <-errChan
+}
+
+func (s *Server) handleStopEvent(eventInfo *EventInfo) error {
+	contextID, err := generateContextID(eventInfo)
+	if err != nil {
+		return fmt.Errorf("Couldn't generate a contextID")
+	}
+
+	// Send the event upstream
+	errChan := s.puHandler.HandlePUEvent(contextID, EventStop)
+	return <-errChan
+}
+
+func (s *Server) handleDestroyEvent(eventInfo *EventInfo) error {
+	contextID, err := generateContextID(eventInfo)
+	if err != nil {
+		return fmt.Errorf("Couldn't generate a contextID")
+	}
+
+	// Send the event upstream
+	errChan := s.puHandler.HandlePUEvent(contextID, EventDestroy)
+	return <-errChan
+}
+
+func (s *Server) handlePauseEvent(eventInfo *EventInfo) error {
+	contextID, err := generateContextID(eventInfo)
+	if err != nil {
+		return fmt.Errorf("Couldn't generate a contextID")
+	}
+
+	errChan := s.puHandler.HandlePUEvent(contextID, EventPause)
+	return <-errChan
 }

--- a/monitor/rpctypes.go
+++ b/monitor/rpctypes.go
@@ -2,6 +2,7 @@ package monitor
 
 // EventInfo contains all the RPC info for a specific event
 type EventInfo struct {
+	PUID      string
 	EventType Event
 	EventName string
 	PID       string

--- a/monitor/rpctypes.go
+++ b/monitor/rpctypes.go
@@ -2,10 +2,12 @@ package monitor
 
 // EventInfo contains all the RPC info for a specific event
 type EventInfo struct {
-	PUID      string
 	EventType Event
-	EventName string
+	PUID      string
+	Name      string
+	Tags      map[string]string
 	PID       string
+	IPs       map[string]string
 }
 
 // RPCResponse encapsulate the error response if any

--- a/monitor/rpctypes.go
+++ b/monitor/rpctypes.go
@@ -1,0 +1,13 @@
+package monitor
+
+// EventInfo contains all the RPC info for a specific event
+type EventInfo struct {
+	EventType Event
+	EventName string
+	PID       string
+}
+
+// RPCResponse encapsulate the error response if any
+type RPCResponse struct {
+	Error string
+}

--- a/monitor/rpctypes.go
+++ b/monitor/rpctypes.go
@@ -1,16 +1,29 @@
 package monitor
 
-// EventInfo contains all the RPC info for a specific event
+// EventInfo is a generic structure that defines all the information related to a PU event.
+// EventInfo should be used as a normalized struct container that
 type EventInfo struct {
+
+	// EventType refers to one of the standard events that Trireme handles.
 	EventType Event
-	PUID      string
-	Name      string
-	Tags      map[string]string
-	PID       string
-	IPs       map[string]string
+
+	// The PUID is a unique value for the Processing Unit. Ideally this should be the UUID.
+	PUID string
+
+	// The Name is a user-friendly name for the Processing Unit.
+	Name string
+
+	// Tags represents the set of MetadataTags associated with this PUID.
+	Tags map[string]string
+
+	// The PID is the PID on the system where this Processing Unit is running.
+	PID string
+
+	// IPs is a map of all the IPs that fully belong to this processing Unit.
+	IPs map[string]string
 }
 
-// RPCResponse encapsulate the error response if any
+// RPCResponse encapsulate the error response if any.
 type RPCResponse struct {
 	Error string
 }


### PR DESCRIPTION
This PR introduces a new monitor that starts a "MonitorServer" over JSON-RPC.

Any Client can connect and send well-defined events (Defined as part of a monitor.RPCType).

This feature will allow interop with CNI and other runtime of the same type.