### PR TITLE
Fixing glide reference on example

### DIFF
--- a/example/glide.lock
+++ b/example/glide.lock
@@ -2,7 +2,7 @@ hash: 779b82d945462f365111c2afa862aa16f84bd722f4e65ccead6f2d993211dd75
 updated: 2016-12-14T16:06:47.286841251-08:00
 imports:
 - name: github.com/aporeto-inc/trireme
-  version: 93dd1e6786c05a4bb5d27eb1a26e596b29852a67
+  version: be09bf84b13f14238ef76673a1c31bcf8b7e6fc0 
   subpackages:
   - cache
   - collector


### PR DESCRIPTION
After latest commit glide.lock in example needs to be updated. 