### PR TITLE
namespace switching code not built for mac

### DIFF
--- a/enforcer/utils/nsenter/nsenter.c
+++ b/enforcer/utils/nsenter/nsenter.c
@@ -18,11 +18,7 @@ void nsexec(void){
   fd = open(path,O_RDONLY);
   int retval = setns(fd,0);
   if(retval < 0){
-    printf("\n\n######\n###########\nFAILED to switch namespace %s container pid %s\n#############\n############  \n\n",strerror(errno),str);
     setenv("NSENTER_ERROR_STATE",strerror(errno),1);
-    exit(errno);
-  }else{
-    setenv("NSENTER_ERROR_STATE"," ",1);
   }
   free(path);
   

--- a/enforcer/utils/nsenter/nsenter.go
+++ b/enforcer/utils/nsenter/nsenter.go
@@ -1,3 +1,4 @@
+// +build linux,!darwin
 package nsenter
 
 /*

--- a/enforcer/utils/nsenter/nsenter_nonlinux.go
+++ b/enforcer/utils/nsenter/nsenter_nonlinux.go
@@ -1,0 +1,7 @@
+// +build !linux
+//Package nsenter for switching namespaces
+package nsenter
+
+//This package should only run on linux
+//Don't test functionality of this package on non linux platforms as
+//the setns call is not available there


### PR DESCRIPTION
A small change to disable setns call on non linux systems. This allows unit tests to run there 
