### PR TITLE
temp: make a workaround for policy with AllowAll to work

### DIFF
--- a/trireme.go
+++ b/trireme.go
@@ -180,6 +180,14 @@ func (t *trireme) doHandleCreate(contextID string) error {
 	runtimeInfo := cachedElement.(*policy.PURuntime)
 	policyInfo, err := t.resolver.ResolvePolicy(contextID, runtimeInfo)
 
+	if policyInfo.TriremeAction == policy.AllowAll {
+		log.WithFields(log.Fields{
+			"package":   "trireme",
+			"contextID": contextID,
+		}).Debug("Resolver returned a PUPolicy with AllowAll Action. Not policing.")
+		return nil
+	}
+
 	if err != nil {
 		log.WithFields(log.Fields{
 			"package":     "trireme",

--- a/trireme_test.go
+++ b/trireme_test.go
@@ -35,7 +35,7 @@ func doTestCreate(t *testing.T, trireme Trireme, tresolver TestPolicyResolver, t
 		}
 
 		ipaddrs := policy.NewIPMap(map[string]string{policy.DefaultNamespace: "127.0.0.1"})
-		tpolicy := policy.NewPUPolicy("SomeId", policy.AllowAll, nil, nil, nil, nil, nil, nil, ipaddrs, nil)
+		tpolicy := policy.NewPUPolicy("SomeId", policy.Police, nil, nil, nil, nil, nil, nil, ipaddrs, nil)
 		resolverCount++
 		return tpolicy, nil
 	})
@@ -260,7 +260,7 @@ func TestSimpleUpdate(t *testing.T) {
 	// Generate a new Policy ...
 	ipl := policy.NewIPMap(map[string]string{policy.DefaultNamespace: "127.0.0.1"})
 	tagsMap := policy.NewTagsMap(map[string]string{enforcer.TransmitterLabel: contextID})
-	newPolicy := policy.NewPUPolicy("", policy.AllowAll, nil, nil, nil, nil, tagsMap, nil, ipl, nil)
+	newPolicy := policy.NewPUPolicy("", policy.Police, nil, nil, nil, nil, tagsMap, nil, ipl, nil)
 	doTestUpdate(t, trireme, tresolver, tsupervisor, tenforcer, tmonitor, contextID, runtime, newPolicy)
 }
 


### PR DESCRIPTION
This patch is a workaround waiting better implementation.

It makes Trireme to ignore any policy with its `TriremeAction` set to `policy.AllowAll`. This works only during policy creation, not update yet.