### PR TITLE
new: added HandleSynchronizationComplete

### DIFF
--- a/monitor/docker.go
+++ b/monitor/docker.go
@@ -340,6 +340,8 @@ func (d *dockerMonitor) syncContainers() error {
 			}
 			d.syncHandler.HandleSynchronization(contextID, state, PURuntime, SynchronizationTypeInitial)
 		}
+
+		d.syncHandler.HandleSynchronizationComplete(SynchronizationTypeInitial)
 	}
 
 	for _, c := range containers {

--- a/monitor/interfaces.go
+++ b/monitor/interfaces.go
@@ -27,4 +27,7 @@ type SynchronizationHandler interface {
 
 	// HandleSynchronization handles a synchronization routine.
 	HandleSynchronization(contextID string, state State, RuntimeReader policy.RuntimeReader, syncType SynchronizationType) error
+
+	// HandleSynchronizationComplete is called when a synchronization job is complete.
+	HandleSynchronizationComplete(syncType SynchronizationType)
 }


### PR DESCRIPTION
This patch enhances the `SynchronizationHandler` interface

```go
// A SynchronizationHandler can handle a PU synchronization routine.
type SynchronizationHandler interface {

	// HandleSynchronization handles a synchronization routine.
	HandleSynchronization(contextID string, state State, RuntimeReader policy.RuntimeReader, syncType SynchronizationType) error

	// HandleSynchronizationComplete is called when a synchronization job is complete.
	HandleSynchronizationComplete(syncType SynchronizationType)
}
```
`HandleSynchronizationComplete` will be called when a sync job has completed, so implementation
can do some post bookkeeping operations if needed.
