### PR TITLE
Fixed: Allow exec path for release agent to be configurable

### DIFF
--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -398,7 +398,7 @@ func NewPSKHybridTriremeWithMonitor(
 	)
 
 	// configure a LinuxServices processor for the rpc monitor
-	linuxMonitorProcessor := linuxmonitor.NewLinuxProcessor(eventCollector, triremeInstance, linuxmonitor.SystemdRPCMetadataExtractor)
+	linuxMonitorProcessor := linuxmonitor.NewLinuxProcessor(eventCollector, triremeInstance, linuxmonitor.SystemdRPCMetadataExtractor, "")
 	rpcmon.RegisterProcessor(constants.LinuxProcessPU, linuxMonitorProcessor)
 
 	return triremeInstance, monitorDocker, rpcmon, triremeInstance.Supervisor(constants.ContainerPU).(supervisor.Excluder)

--- a/monitor/dockermonitor/docker.go
+++ b/monitor/dockermonitor/docker.go
@@ -205,7 +205,6 @@ func (d *dockerMonitor) Start() error {
 
 	//Syncing all Existing containers depending on MonitorSetting
 	if d.syncAtStart {
-		fmt.Println("Start sync ")
 		err := d.syncContainers()
 
 		if err != nil {
@@ -324,7 +323,6 @@ func (d *dockerMonitor) syncContainers() error {
 	}
 
 	if d.syncHandler != nil {
-		fmt.Println("starting sync .. found the handler ")
 		for _, c := range containers {
 			container, err := d.dockerClient.ContainerInspect(context.Background(), c.ID)
 

--- a/monitor/dockermonitor/docker.go
+++ b/monitor/dockermonitor/docker.go
@@ -205,6 +205,7 @@ func (d *dockerMonitor) Start() error {
 
 	//Syncing all Existing containers depending on MonitorSetting
 	if d.syncAtStart {
+		fmt.Println("Start sync ")
 		err := d.syncContainers()
 
 		if err != nil {
@@ -323,6 +324,7 @@ func (d *dockerMonitor) syncContainers() error {
 	}
 
 	if d.syncHandler != nil {
+		fmt.Println("starting sync .. found the handler ")
 		for _, c := range containers {
 			container, err := d.dockerClient.ContainerInspect(context.Background(), c.ID)
 

--- a/monitor/linuxmonitor/cgnetcls/cgnetcls_osx.go
+++ b/monitor/linuxmonitor/cgnetcls/cgnetcls_osx.go
@@ -49,7 +49,7 @@ func (s *netCls) RemoveProcess(cgroupname string, pid int) error {
 }
 
 //NewCgroupNetController returns a handle to call functions on the cgroup net_cls controller
-func NewCgroupNetController() Cgroupnetcls {
+func NewCgroupNetController(releasePath string) Cgroupnetcls {
 
 	return nil
 }

--- a/monitor/linuxmonitor/cgnetcls/cgnetcls_test.go
+++ b/monitor/linuxmonitor/cgnetcls/cgnetcls_test.go
@@ -34,7 +34,7 @@ func TestCreategroup(t *testing.T) {
 		t.SkipNow()
 	}
 
-	cg := NewCgroupNetController()
+	cg := NewCgroupNetController("")
 	err := cg.Creategroup(testcgroupname)
 	defer cleanupnetclsgroup()
 
@@ -91,7 +91,7 @@ func TestCreategroup(t *testing.T) {
 }
 
 func TestAssignMark(t *testing.T) {
-	cg := NewCgroupNetController()
+	cg := NewCgroupNetController("")
 	if os.Getenv("USER") != "root" {
 		t.SkipNow()
 	}
@@ -129,7 +129,7 @@ func TestAddProcess(t *testing.T) {
 	if os.Getenv("USER") != "root" {
 		t.SkipNow()
 	}
-	cg := NewCgroupNetController()
+	cg := NewCgroupNetController("")
 	//AddProcess to a non-existent group
 	err := cg.AddProcess(testcgroupname, os.Getpid())
 	if err == nil {
@@ -172,7 +172,7 @@ func TestRemoveProcess(t *testing.T) {
 	if os.Getenv("USER") != "root" {
 		t.SkipNow()
 	}
-	cg := NewCgroupNetController()
+	cg := NewCgroupNetController("")
 	//Removing process from non-existent group
 	err := cg.RemoveProcess(testcgroupname, 1)
 	if err == nil {
@@ -198,7 +198,7 @@ func TestDeleteCgroup(t *testing.T) {
 	if os.Getenv("USER") != "root" {
 		t.SkipNow()
 	}
-	cg := NewCgroupNetController()
+	cg := NewCgroupNetController("")
 	//Removing process from non-existent group
 	err := cg.DeleteCgroup(testcgroupname)
 	if err != nil {
@@ -219,7 +219,7 @@ func TestDeleteBasePath(t *testing.T) {
 	if os.Getenv("USER") != "root" {
 		t.SkipNow()
 	}
-	cg := NewCgroupNetController()
+	cg := NewCgroupNetController("")
 	//Removing process from non-existent group
 	err := cg.DeleteCgroup(testcgroupname)
 	defer cleanupnetclsgroup()

--- a/monitor/linuxmonitor/processor.go
+++ b/monitor/linuxmonitor/processor.go
@@ -25,13 +25,13 @@ type LinuxProcessor struct {
 }
 
 // NewLinuxProcessor initializes a processor
-func NewLinuxProcessor(collector collector.EventCollector, puHandler monitor.ProcessingUnitsHandler, metadataExtractor rpcmonitor.RPCMetadataExtractor) *LinuxProcessor {
+func NewLinuxProcessor(collector collector.EventCollector, puHandler monitor.ProcessingUnitsHandler, metadataExtractor rpcmonitor.RPCMetadataExtractor, releasePath string) *LinuxProcessor {
 
 	return &LinuxProcessor{
 		collector:         collector,
 		puHandler:         puHandler,
 		metadataExtractor: metadataExtractor,
-		netcls:            cgnetcls.NewCgroupNetController(),
+		netcls:            cgnetcls.NewCgroupNetController(releasePath),
 	}
 }
 

--- a/monitor/linuxmonitor/processor_test.go
+++ b/monitor/linuxmonitor/processor_test.go
@@ -1,4 +1,4 @@
-NewLinuxProcessorpackage linuxmonitor
+package linuxmonitor
 
 import (
 	"fmt"

--- a/monitor/linuxmonitor/processor_test.go
+++ b/monitor/linuxmonitor/processor_test.go
@@ -1,4 +1,4 @@
-package linuxmonitor
+NewLinuxProcessorpackage linuxmonitor
 
 import (
 	"fmt"
@@ -20,7 +20,7 @@ type CustomPolicyResolver struct {
 
 func TestNewLinuxProcessor(t *testing.T) {
 	Convey("When I initialize a new processor", t, func() {
-		p := NewLinuxProcessor(nil, &CustomPolicyResolver{}, rpcmonitor.DefaultRPCMetadataExtractor)
+		p := NewLinuxProcessor(nil, &CustomPolicyResolver{}, rpcmonitor.DefaultRPCMetadataExtractor, "")
 
 		Convey("I should get a valid processor", func() {
 			So(p, ShouldNotBeNil)
@@ -36,7 +36,7 @@ func TestCreate(t *testing.T) {
 
 	Convey("Given a valid processor", t, func() {
 		puHandler := mock_trireme.NewMockProcessingUnitsHandler(ctrl)
-		p := NewLinuxProcessor(&collector.DefaultCollector{}, puHandler, rpcmonitor.DefaultRPCMetadataExtractor)
+		p := NewLinuxProcessor(&collector.DefaultCollector{}, puHandler, rpcmonitor.DefaultRPCMetadataExtractor, "")
 
 		Convey("When I get an event with no PUID", func() {
 			event := &rpcmonitor.EventInfo{
@@ -69,7 +69,7 @@ func TestStop(t *testing.T) {
 
 	Convey("Given a valid processor", t, func() {
 		puHandler := mock_trireme.NewMockProcessingUnitsHandler(ctrl)
-		p := NewLinuxProcessor(&collector.DefaultCollector{}, puHandler, rpcmonitor.DefaultRPCMetadataExtractor)
+		p := NewLinuxProcessor(&collector.DefaultCollector{}, puHandler, rpcmonitor.DefaultRPCMetadataExtractor, "")
 		p.netcls = mock_cgnetcls.NewMockCgroupnetcls(ctrl)
 
 		Convey("When I get a stop event with no PUID", func() {
@@ -115,7 +115,7 @@ func TestDestroy(t *testing.T) {
 
 	Convey("Given a valid processor", t, func() {
 		puHandler := mock_trireme.NewMockProcessingUnitsHandler(ctrl)
-		p := NewLinuxProcessor(&collector.DefaultCollector{}, puHandler, rpcmonitor.DefaultRPCMetadataExtractor)
+		p := NewLinuxProcessor(&collector.DefaultCollector{}, puHandler, rpcmonitor.DefaultRPCMetadataExtractor, "")
 		mockcls := mock_cgnetcls.NewMockCgroupnetcls(ctrl)
 		p.netcls = mockcls
 
@@ -164,7 +164,7 @@ func TestPause(t *testing.T) {
 
 	Convey("Given a valid processor", t, func() {
 		puHandler := mock_trireme.NewMockProcessingUnitsHandler(ctrl)
-		p := NewLinuxProcessor(&collector.DefaultCollector{}, puHandler, rpcmonitor.DefaultRPCMetadataExtractor)
+		p := NewLinuxProcessor(&collector.DefaultCollector{}, puHandler, rpcmonitor.DefaultRPCMetadataExtractor, "")
 
 		Convey("When I get a pause event with no PUID", func() {
 			event := &rpcmonitor.EventInfo{
@@ -198,7 +198,7 @@ func TestStart(t *testing.T) {
 
 	Convey("Given a valid processor", t, func() {
 		puHandler := mock_trireme.NewMockProcessingUnitsHandler(ctrl)
-		p := NewLinuxProcessor(&collector.DefaultCollector{}, puHandler, rpcmonitor.DefaultRPCMetadataExtractor)
+		p := NewLinuxProcessor(&collector.DefaultCollector{}, puHandler, rpcmonitor.DefaultRPCMetadataExtractor, "")
 
 		Convey("When I get a start event with no PUID", func() {
 			event := &rpcmonitor.EventInfo{


### PR DESCRIPTION
With this PR the executable path for the release agent for Linux processes can be programmed
and its not always the executable of the library. This allow flexibility for different CLI 
configurations. 