### PR TITLE
Fixing race in Marval. Changed to a much simpler function

### DIFF
--- a/monitor/linuxmonitor/cgnetcls/cgnetcls.go
+++ b/monitor/linuxmonitor/cgnetcls/cgnetcls.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 
 	log "github.com/Sirupsen/logrus"
@@ -225,19 +226,8 @@ func NewCgroupNetController(releasePath string) Cgroupnetcls {
 }
 
 // MarkVal returns a new Mark Value
-func MarkVal() <-chan string {
-
-	ch := make(chan string)
-
-	go func() {
-		for {
-			ch <- strconv.FormatUint(markval, 10)
-			markval = markval + 1
-		}
-	}()
-
-	return ch
-
+func MarkVal() uint64 {
+	return atomic.AddUint64(&markval, 1)
 }
 
 // ListCgroupProcesses lists the processes of the cgroup

--- a/monitor/linuxmonitor/linuxMonitor.go
+++ b/monitor/linuxmonitor/linuxMonitor.go
@@ -61,7 +61,7 @@ func SystemdRPCMetadataExtractor(event *rpcmonitor.EventInfo) (*policy.PURuntime
 		options.Tags[cgnetcls.PortTag] = runtimeTags.Tags[cgnetcls.PortTag]
 	}
 
-	options.Tags[cgnetcls.CgroupMarkTag] = <-cgnetcls.MarkVal()
+	options.Tags[cgnetcls.CgroupMarkTag] = strconv.FormatUint(cgnetcls.MarkVal(), 10)
 
 	runtimeIps := policy.NewIPMap(map[string]string{"bridge": "0.0.0.0/0"})
 


### PR DESCRIPTION
Fixed the function that generates markid for cgroups/linux processes managed by trireme as they are created. 