### PR TITLE
Separating user and system tags in extractors

### DIFF
--- a/monitor/dockermonitor/docker.go
+++ b/monitor/dockermonitor/docker.go
@@ -105,11 +105,12 @@ func initDockerClient(socketType string, socketAddress string) (*dockerClient.Cl
 func defaultDockerMetadataExtractor(info *types.ContainerJSON) (*policy.PURuntime, error) {
 
 	tags := policy.NewTagsMap(map[string]string{
-		"image": info.Config.Image,
-		"name":  info.Name,
+		"@sys:image": info.Config.Image,
+		"@sys:name":  info.Name,
 	})
+
 	for k, v := range info.Config.Labels {
-		tags.Add(k, v)
+		tags.Add("@usr:"+k, v)
 	}
 
 	ipa := policy.NewIPMap(map[string]string{

--- a/monitor/linuxmonitor/cgnetcls/cgnetcls.go
+++ b/monitor/linuxmonitor/cgnetcls/cgnetcls.go
@@ -24,7 +24,7 @@ const (
 	procs                = "/cgroup.procs"
 	CgroupNameTag        = "@cgroup_name"
 	CgroupMarkTag        = "@cgroup_mark"
-	PortTag              = "port"
+	PortTag              = "@usr:port"
 	releaseAgentConfFile = "/release_agent"
 	notifyOnReleaseFile  = "/notify_on_release"
 	initialmarkval       = 100

--- a/monitor/linuxmonitor/linuxMonitor.go
+++ b/monitor/linuxmonitor/linuxMonitor.go
@@ -33,23 +33,27 @@ func SystemdRPCMetadataExtractor(event *rpcmonitor.EventInfo) (*policy.PURuntime
 		return nil, fmt.Errorf("EventInfo PUID is empty")
 	}
 
-	runtimeTags := policy.NewTagsMap(event.Tags)
+	runtimeTags := policy.NewTagsMap(map[string]string{})
+
+	for k, v := range event.Tags {
+		runtimeTags.Tags["@usr:"+k] = v
+	}
 
 	userdata := processInfo(event.PID)
 
 	for _, u := range userdata {
-		runtimeTags.Tags[u] = "true"
+		runtimeTags.Tags["@sys:"+u] = "true"
 	}
 
-	runtimeTags.Tags["hostname"] = findFQFN()
+	runtimeTags.Tags["@sys:hostname"] = findFQFN()
 
 	if fileMd5, err := ComputeMd5(event.Name); err == nil {
-		runtimeTags.Tags["FileChecksum"] = hex.EncodeToString(fileMd5)
+		runtimeTags.Tags["@sys:fileChecksum"] = hex.EncodeToString(fileMd5)
 	}
 
 	depends := libs(event.Name)
 	for _, lib := range depends {
-		runtimeTags.Tags["lib:"+lib] = "true"
+		runtimeTags.Tags["@sys:lib:"+lib] = "true"
 	}
 
 	options := policy.NewTagsMap(map[string]string{

--- a/monitor/linuxmonitor/linuxMonitor.go
+++ b/monitor/linuxmonitor/linuxMonitor.go
@@ -48,7 +48,7 @@ func SystemdRPCMetadataExtractor(event *rpcmonitor.EventInfo) (*policy.PURuntime
 	runtimeTags.Tags["@sys:hostname"] = findFQFN()
 
 	if fileMd5, err := ComputeMd5(event.Name); err == nil {
-		runtimeTags.Tags["@sys:fileChecksum"] = hex.EncodeToString(fileMd5)
+		runtimeTags.Tags["@sys:filechecksum"] = hex.EncodeToString(fileMd5)
 	}
 
 	depends := libs(event.Name)


### PR DESCRIPTION
Default extractors will use different notations for system defined and user labels. System labels (auto-discovered) will start with @sys: and user labels with @usr . Policies can now decide which labels they want to trust.