### PR TITLE
Make exclusions part of the policy interface

### DIFF
--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -61,8 +61,7 @@ func NewTriremeLinuxProcess(
 	}
 
 	supervisors := map[constants.PUType]supervisor.Supervisor{constants.ContainerPU: s}
-	excluder := map[constants.PUType]supervisor.Excluder{constants.ContainerPU: s}
-	return trireme.NewTrireme(serverID, resolver, supervisors, excluder, enforcers, eventCollector)
+	return trireme.NewTrireme(serverID, resolver, supervisors, enforcers, eventCollector)
 }
 
 // NewLocalTriremeDocker instantiates Trireme for Docker using enforcement on the
@@ -105,8 +104,7 @@ func NewLocalTriremeDocker(
 	}
 
 	supervisors := map[constants.PUType]supervisor.Supervisor{constants.ContainerPU: s}
-	excluder := map[constants.PUType]supervisor.Excluder{constants.ContainerPU: s}
-	return trireme.NewTrireme(serverID, resolver, supervisors, excluder, enforcers, eventCollector)
+	return trireme.NewTrireme(serverID, resolver, supervisors, enforcers, eventCollector)
 }
 
 // NewDistributedTriremeDocker instantiates Trireme using remote enforcers on
@@ -144,8 +142,7 @@ func NewDistributedTriremeDocker(serverID string,
 	}
 
 	supervisors := map[constants.PUType]supervisor.Supervisor{constants.ContainerPU: s}
-	excluders := map[constants.PUType]supervisor.Excluder{constants.ContainerPU: s}
-	return trireme.NewTrireme(serverID, resolver, supervisors, excluders, enforcers, eventCollector)
+	return trireme.NewTrireme(serverID, resolver, supervisors, enforcers, eventCollector)
 }
 
 // NewHybridTrireme instantiates Trireme with both Linux and Docker enforcers.
@@ -216,11 +213,8 @@ func NewHybridTrireme(
 		constants.ContainerPU:    containerSupervisor,
 		constants.LinuxProcessPU: processSupervisor,
 	}
-	excluders := map[constants.PUType]supervisor.Excluder{
-		constants.ContainerPU:    containerSupervisor,
-		constants.LinuxProcessPU: processSupervisor,
-	}
-	trireme := trireme.NewTrireme(serverID, resolver, supervisors, excluders, enforcers, eventCollector)
+
+	trireme := trireme.NewTrireme(serverID, resolver, supervisors, enforcers, eventCollector)
 
 	return trireme
 }
@@ -247,7 +241,7 @@ func NewPSKTriremeWithDockerMonitor(
 	key []byte,
 	dockerMetadataExtractor dockermonitor.DockerMetadataExtractor,
 	remoteEnforcer bool,
-) (trireme.Trireme, monitor.Monitor, supervisor.Excluder) {
+) (trireme.Trireme, monitor.Monitor) {
 
 	if eventCollector == nil {
 		log.WithFields(log.Fields{
@@ -287,7 +281,7 @@ func NewPSKTriremeWithDockerMonitor(
 		syncAtStart,
 		nil)
 
-	return triremeInstance, monitorInstance, triremeInstance.Supervisor(constants.ContainerPU).(supervisor.Excluder)
+	return triremeInstance, monitorInstance
 
 }
 
@@ -306,7 +300,7 @@ func NewPKITriremeWithDockerMonitor(
 	caCertPEM []byte,
 	dockerMetadataExtractor dockermonitor.DockerMetadataExtractor,
 	remoteEnforcer bool,
-) (trireme.Trireme, monitor.Monitor, supervisor.Excluder, enforcer.PublicKeyAdder) {
+) (trireme.Trireme, monitor.Monitor, enforcer.PublicKeyAdder) {
 
 	if eventCollector == nil {
 		log.WithFields(log.Fields{
@@ -346,7 +340,7 @@ func NewPKITriremeWithDockerMonitor(
 		syncAtStart,
 		nil)
 
-	return triremeInstance, monitorInstance, triremeInstance.Supervisor(constants.ContainerPU).(supervisor.Excluder), publicKeyAdder
+	return triremeInstance, monitorInstance, publicKeyAdder
 
 }
 
@@ -361,7 +355,7 @@ func NewPSKHybridTriremeWithMonitor(
 	syncAtStart bool,
 	key []byte,
 	dockerMetadataExtractor dockermonitor.DockerMetadataExtractor,
-) (trireme.Trireme, monitor.Monitor, monitor.Monitor, supervisor.Excluder) {
+) (trireme.Trireme, monitor.Monitor, monitor.Monitor) {
 
 	if eventCollector == nil {
 		log.WithFields(log.Fields{
@@ -410,6 +404,6 @@ func NewPSKHybridTriremeWithMonitor(
 		}).Fatal("Failed to initialize RPC monitor")
 	}
 
-	return triremeInstance, monitorDocker, rpcmon, triremeInstance.Supervisor(constants.ContainerPU).(supervisor.Excluder)
+	return triremeInstance, monitorDocker, rpcmon
 
 }

--- a/enforcer/proxy/enforcerproxy.go
+++ b/enforcer/proxy/enforcerproxy.go
@@ -122,6 +122,7 @@ func (s *proxyInfo) Enforce(contextID string, puInfo *policy.PUInfo) error {
 			ReceiverRules:    puInfo.Policy.ReceiverRules(),
 			TransmitterRules: puInfo.Policy.TransmitterRules(),
 			TriremeNetworks:  puInfo.Policy.TriremeNetworks(),
+			ExcludedNetworks: puInfo.Policy.ExcludedNetworks(),
 		},
 	}
 

--- a/enforcer/utils/rpcwrapper/types.go
+++ b/enforcer/utils/rpcwrapper/types.go
@@ -67,6 +67,7 @@ type EnforcePayload struct {
 	ReceiverRules    *policy.TagSelectorList `json:",omitempty"`
 	TransmitterRules *policy.TagSelectorList `json:",omitempty"`
 	TriremeNetworks  []string                `json:",omitempty"`
+	ExcludedNetworks []string                `json:",omitempty"`
 }
 
 //SuperviseRequestPayload for Supervise request
@@ -81,7 +82,7 @@ type SuperviseRequestPayload struct {
 	Annotations      *policy.TagsMap         `json:",omitempty"`
 	ReceiverRules    *policy.TagSelectorList `json:",omitempty"`
 	TransmitterRules *policy.TagSelectorList `json:",omitempty"`
-	ExcludedIPs      []string                `json:",omitempty"`
+	ExcludedNetworks []string                `json:",omitempty"`
 	TriremeNetworks  []string                `json:",omitempty"`
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -22,9 +22,6 @@ type Trireme interface {
 	// Supervisor returns the supervisor for a given PU type
 	Supervisor(kind constants.PUType) supervisor.Supervisor
 
-	//AddExcludedIPList adds the ips to all supervisor instances managed by this trireme instance
-
-	AddExcludedIPList(ipList []string) error
 	monitor.ProcessingUnitsHandler
 
 	PolicyUpdater

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -29,6 +29,8 @@ type PUPolicy struct {
 	ips *IPMap
 	// triremeNetworks is the list of networks that Authorization must be enforced
 	triremeNetworks []string
+	// excludedNetworks a list of networks that must be excluded
+	excludedNetworks []string
 	// Extensions is an interface to a data structure that allows the policy supervisor
 	// to pass additional instructions to a plugin. Plugin and policy must be
 	// coordinated to implement the interface
@@ -45,6 +47,7 @@ func NewPUPolicy(
 	identity, annotations *TagsMap,
 	ips *IPMap,
 	triremeNetworks []string,
+	excludedNetworks []string,
 	e interface{}) *PUPolicy {
 
 	if ingress == nil {
@@ -80,6 +83,7 @@ func NewPUPolicy(
 		annotations:      annotations,
 		ips:              ips,
 		triremeNetworks:  triremeNetworks,
+		excludedNetworks: excludedNetworks,
 		Extensions:       e,
 	}
 }
@@ -87,7 +91,7 @@ func NewPUPolicy(
 // NewPUPolicyWithDefaults sets up a PU policy with defaults
 func NewPUPolicyWithDefaults() *PUPolicy {
 
-	return NewPUPolicy("", AllowAll, nil, nil, nil, nil, nil, nil, nil, []string{}, nil)
+	return NewPUPolicy("", AllowAll, nil, nil, nil, nil, nil, nil, nil, []string{}, []string{}, nil)
 }
 
 // Clone returns a copy of the policy
@@ -106,6 +110,7 @@ func (p *PUPolicy) Clone() *PUPolicy {
 		p.annotations.Clone(),
 		p.ips.Clone(),
 		p.triremeNetworks,
+		p.excludedNetworks,
 		p.Extensions,
 	)
 
@@ -223,4 +228,18 @@ func (p *PUPolicy) UpdateTriremeNetworks(networks []string) {
 
 	p.triremeNetworks = []string{}
 	p.triremeNetworks = append(p.triremeNetworks, networks...)
+}
+
+// ExcludedNetworks returns the list of excluded networks.
+func (p *PUPolicy) ExcludedNetworks() []string {
+	return p.excludedNetworks
+}
+
+// UpdateExcludedNetworks updates the list of excluded networks.
+func (p *PUPolicy) UpdateExcludedNetworks(networks []string) {
+	p.puPolicyMutex.Lock()
+	defer p.puPolicyMutex.Unlock()
+
+	p.excludedNetworks = []string{}
+	p.excludedNetworks = append(p.excludedNetworks, networks...)
 }

--- a/policy/puinfo.go
+++ b/policy/puinfo.go
@@ -14,7 +14,7 @@ type PUInfo struct {
 
 // NewPUInfo instantiates a new ContainerPolicy
 func NewPUInfo(contextID string, puType constants.PUType) *PUInfo {
-	policy := NewPUPolicy("", AllowAll, nil, nil, nil, nil, nil, nil, nil, []string{}, nil)
+	policy := NewPUPolicy("", AllowAll, nil, nil, nil, nil, nil, nil, nil, []string{}, []string{}, nil)
 	runtime := NewPURuntime("", 0, nil, nil, puType, nil)
 	return PUInfoFromPolicyAndRuntime(contextID, policy, runtime)
 }

--- a/supervisor/interfaces.go
+++ b/supervisor/interfaces.go
@@ -18,15 +18,6 @@ type Supervisor interface {
 	Stop() error
 }
 
-// Excluder is an interface to remove specific IPs from the Trireme implementation
-type Excluder interface {
-
-	// AddExcludedIPs adds an exception for the destination parameter IPs,
-	// allowing the traffic out of that IP range to be treated as non-trireme traffic.
-	// That traffic is by definition still subject to ACLs.
-	AddExcludedIPs(ips []string) error
-}
-
 // Implementor is the interface of the implementation based on iptables, ipsets, remote etc
 type Implementor interface {
 
@@ -44,10 +35,4 @@ type Implementor interface {
 
 	// Stop cleans up state
 	Stop() error
-
-	// AddExcludedIP adds an exception for the destination parameter IP, allowing all the traffic.
-	AddExcludedIP(ip []string) error
-
-	// RemoveExcludedIP removes the exception for the destination IP given in parameter.
-	RemoveExcludedIP(ip []string) error
 }

--- a/supervisor/ipsetctrl/ipsetctrl_test.go
+++ b/supervisor/ipsetctrl/ipsetctrl_test.go
@@ -133,6 +133,7 @@ func TestConfigureRules(t *testing.T) {
 				nil,
 				ipl,
 				[]string{},
+				[]string{},
 				nil)
 			containerinfo := policy.NewPUInfo("Context", constants.ContainerPU)
 			containerinfo.Policy = policyrules
@@ -155,6 +156,7 @@ func TestConfigureRules(t *testing.T) {
 			nil,
 			nil,
 			ipl,
+			[]string{},
 			[]string{},
 			nil)
 
@@ -315,7 +317,7 @@ func TestUpdateRules(t *testing.T) {
 			nil,
 			nil,
 			nil,
-			nil, ipl, []string{"172.17.0.0/24"}, nil)
+			nil, ipl, []string{"172.17.0.0/24"}, []string{}, nil)
 
 		containerinfo := policy.NewPUInfo("Context", constants.ContainerPU)
 		containerinfo.Policy = policyrules

--- a/supervisor/iptablesctrl/acls_test.go
+++ b/supervisor/iptablesctrl/acls_test.go
@@ -714,7 +714,7 @@ func TestRemoveMarkRule(t *testing.T) {
 	})
 }
 
-func TestAddExclusionChainRules(t *testing.T) {
+func TestAddExclusionACLs(t *testing.T) {
 	Convey("Given an iptables controller", t, func() {
 		i, _ := NewInstance("0:1", "2:3", 0x1000, constants.LocalContainer)
 		iptables := provider.NewTestIptablesProvider()
@@ -724,7 +724,8 @@ func TestAddExclusionChainRules(t *testing.T) {
 			iptables.MockInsert(t, func(table string, chain string, pos int, rulespec ...string) error {
 				return nil
 			})
-			err := i.addExclusionChainRules([]string{"172.17.0.1"})
+
+			err := i.addExclusionACLs("appchain", "netchain", "1.2.3.4/32", []string{"10.1.1.1/32"})
 			Convey("I should get no error", func() {
 				So(err, ShouldBeNil)
 			})
@@ -732,73 +733,29 @@ func TestAddExclusionChainRules(t *testing.T) {
 
 		Convey("When I add the exclusion chain rules and the appPacketIPTableContext fails ", func() {
 			iptables.MockInsert(t, func(table string, chain string, pos int, rulespec ...string) error {
-				if table == i.appPacketIPTableContext {
-					return fmt.Errorf("Error")
-				}
-				return nil
-			})
-			err := i.addExclusionChainRules([]string{"172.17.0.1"})
-			Convey("I should get  error", func() {
-				So(err, ShouldNotBeNil)
-			})
-		})
-
-		Convey("When I add the exclusion chain rules and the appAckPacketIPTableContext fails ", func() {
-			iptables.MockInsert(t, func(table string, chain string, pos int, rulespec ...string) error {
 				if table == i.appAckPacketIPTableContext {
 					return fmt.Errorf("Error")
 				}
 				return nil
 			})
-			err := i.addExclusionChainRules([]string{"172.17.0.1"})
+			err := i.addExclusionACLs("appchain", "netchain", "1.2.3.4/32", []string{"10.1.1.1/32"})
 			Convey("I should get  error", func() {
 				So(err, ShouldNotBeNil)
 			})
 		})
 
-		Convey("When I add the exclusion chain rules and the netPacketIPtableContext fails ", func() {
+		Convey("When I add the exclusion chain rules and the netPacketIPTableContext fails ", func() {
 			iptables.MockInsert(t, func(table string, chain string, pos int, rulespec ...string) error {
 				if table == i.netPacketIPTableContext {
 					return fmt.Errorf("Error")
 				}
 				return nil
 			})
-			err := i.addExclusionChainRules([]string{"172.17.0.1"})
+			err := i.addExclusionACLs("appchain", "netchain", "1.2.3.4/32", []string{"10.1.1.1/32"})
 			Convey("I should get  error", func() {
 				So(err, ShouldNotBeNil)
 			})
 		})
-
-	})
-}
-
-func TestDeleteExclusionChainRules(t *testing.T) {
-
-	Convey("Given an iptables controller", t, func() {
-		i, _ := NewInstance("0:1", "2:3", 0x1000, constants.LocalContainer)
-		iptables := provider.NewTestIptablesProvider()
-		i.ipt = iptables
-
-		Convey("When I delete the exclusion chain rules and it succeeds", func() {
-			iptables.MockDelete(t, func(table string, chain string, rulespec ...string) error {
-				return nil
-			})
-			err := i.deleteExclusionChainRules([]string{"172.17.0.1"})
-			Convey("I should get no error", func() {
-				So(err, ShouldBeNil)
-			})
-		})
-
-		Convey("When I delete the chain rules and it fails", func() {
-			iptables.MockDelete(t, func(table string, chain string, rulespec ...string) error {
-				return nil
-			})
-			err := i.deleteExclusionChainRules([]string{"172.17.0.1"})
-			Convey("I should still get no error", func() {
-				So(err, ShouldBeNil)
-			})
-		})
-
 	})
 }
 

--- a/supervisor/iptablesctrl/iptables.go
+++ b/supervisor/iptablesctrl/iptables.go
@@ -141,6 +141,10 @@ func (i *Instance) ConfigureRules(version int, contextID string, containerInfo *
 		return err
 	}
 
+	if err := i.addExclusionACLs(appChain, netChain, ipAddress, policyrules.ExcludedNetworks()); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -220,6 +224,10 @@ func (i *Instance) UpdateRules(version int, contextID string, containerInfo *pol
 	}
 
 	if err := i.addNetACLs(netChain, ipAddress, policyrules.NetworkACLs()); err != nil {
+		return err
+	}
+
+	if err := i.addExclusionACLs(appChain, netChain, ipAddress, policyrules.ExcludedNetworks()); err != nil {
 		return err
 	}
 
@@ -318,16 +326,4 @@ func (i *Instance) Stop() error {
 		}).Warn("Failed to clean acls while stopping the supervisor")
 	}
 	return nil
-}
-
-// AddExcludedIP adds an exception for the destination parameter IP, allowing all the traffic.
-func (i *Instance) AddExcludedIP(ip []string) error {
-
-	return i.addExclusionChainRules(ip)
-}
-
-// RemoveExcludedIP removes the exception for the destion IP given in parameter.
-func (i *Instance) RemoveExcludedIP(ip []string) error {
-
-	return i.deleteExclusionChainRules(ip)
 }

--- a/supervisor/iptablesctrl/iptables_test.go
+++ b/supervisor/iptablesctrl/iptables_test.go
@@ -144,7 +144,7 @@ func TestConfigureRules(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				nil, ipl, []string{"172.17.0.0/24"}, nil)
+				nil, ipl, []string{"172.17.0.0/24"}, []string{}, nil)
 
 			containerinfo := policy.NewPUInfo("Context", constants.ContainerPU)
 			containerinfo.Policy = policyrules
@@ -172,7 +172,7 @@ func TestConfigureRules(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				nil, ipl, []string{"172.17.0.0/24"}, nil)
+				nil, ipl, []string{"172.17.0.0/24"}, []string{}, nil)
 
 			containerinfo := policy.NewPUInfo("Context", constants.ContainerPU)
 			containerinfo.Policy = policyrules
@@ -195,7 +195,7 @@ func TestConfigureRules(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				nil, ipl, []string{"172.17.0.0/24"}, nil)
+				nil, ipl, []string{"172.17.0.0/24"}, []string{}, nil)
 
 			containerinfo := policy.NewPUInfo("Context", constants.ContainerPU)
 			containerinfo.Policy = policyrules
@@ -226,7 +226,7 @@ func TestConfigureRules(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				nil, ipl, []string{"172.17.0.0/24"}, nil)
+				nil, ipl, []string{"172.17.0.0/24"}, []string{}, nil)
 
 			containerinfo := policy.NewPUInfo("Context", constants.ContainerPU)
 			containerinfo.Policy = policyrules
@@ -330,7 +330,7 @@ func TestUpdateRules(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				nil, ipl, []string{"172.17.0.0/24"}, nil)
+				nil, ipl, []string{"172.17.0.0/24"}, []string{}, nil)
 
 			containerinfo := policy.NewPUInfo("Context", constants.ContainerPU)
 			containerinfo.Policy = policyrules
@@ -393,7 +393,7 @@ func TestUpdateRules(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				nil, ipl, []string{"172.17.0.0/24"}, nil)
+				nil, ipl, []string{"172.17.0.0/24"}, []string{}, nil)
 
 			containerinfo := policy.NewPUInfo("Context", constants.ContainerPU)
 			containerinfo.Policy = policyrules
@@ -464,73 +464,5 @@ func TestStop(t *testing.T) {
 			err := i.Stop()
 			So(err, ShouldBeNil)
 		})
-	})
-}
-
-func TestAddExcludedIP(t *testing.T) {
-	Convey("Given an iptables controller", t, func() {
-		i, _ := NewInstance("0:1", "2:3", 0x1000, constants.RemoteContainer)
-		iptables := provider.NewTestIptablesProvider()
-		i.ipt = iptables
-
-		Convey("When I add an excluded IP 10.1.1.0", func() {
-			iptables.MockInsert(t, func(table string, chain string, pos int, rulespec ...string) error {
-				if matchSpec("10.1.1.0", rulespec) == nil {
-					return nil
-				}
-				return fmt.Errorf("Error")
-			})
-
-			err := i.AddExcludedIP([]string{"10.1.1.0"})
-			Convey("I should get no error", func() {
-				So(err, ShouldBeNil)
-			})
-		})
-
-		Convey("When I add an excluded IP 10.1.1.0 and it fails ", func() {
-			iptables.MockInsert(t, func(table string, chain string, pos int, rulespec ...string) error {
-				return fmt.Errorf("Error")
-			})
-
-			err := i.AddExcludedIP([]string{"10.1.1.0"})
-			Convey("I should get  error", func() {
-				So(err, ShouldNotBeNil)
-			})
-		})
-
-	})
-}
-
-func TestRemoveExcludedIP(t *testing.T) {
-	Convey("Given an iptables controller", t, func() {
-		i, _ := NewInstance("0:1", "2:3", 0x1000, constants.RemoteContainer)
-		iptables := provider.NewTestIptablesProvider()
-		i.ipt = iptables
-
-		Convey("When I remove an excluded IP 10.1.1.0", func() {
-			iptables.MockDelete(t, func(table string, chain string, rulespec ...string) error {
-				if matchSpec("10.1.1.0", rulespec) == nil {
-					return nil
-				}
-				return fmt.Errorf("Error")
-			})
-
-			err := i.RemoveExcludedIP([]string{"10.1.1.0"})
-			Convey("I should get no error", func() {
-				So(err, ShouldBeNil)
-			})
-		})
-
-		Convey("When I remove an excluded IP 10.1.1.0 and it fails ", func() {
-			iptables.MockDelete(t, func(table string, chain string, rulespec ...string) error {
-				return fmt.Errorf("Error")
-			})
-
-			err := i.RemoveExcludedIP([]string{"10.1.1.0"})
-			Convey("I should get  error", func() {
-				So(err, ShouldNotBeNil)
-			})
-		})
-
 	})
 }

--- a/supervisor/mock/mock_interfaces.go
+++ b/supervisor/mock/mock_interfaces.go
@@ -70,37 +70,6 @@ func (_mr *_MockSupervisorRecorder) Stop() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Stop")
 }
 
-// Mock of Excluder interface
-type MockExcluder struct {
-	ctrl     *gomock.Controller
-	recorder *_MockExcluderRecorder
-}
-
-// Recorder for MockExcluder (not exported)
-type _MockExcluderRecorder struct {
-	mock *MockExcluder
-}
-
-func NewMockExcluder(ctrl *gomock.Controller) *MockExcluder {
-	mock := &MockExcluder{ctrl: ctrl}
-	mock.recorder = &_MockExcluderRecorder{mock}
-	return mock
-}
-
-func (_m *MockExcluder) EXPECT() *_MockExcluderRecorder {
-	return _m.recorder
-}
-
-func (_m *MockExcluder) AddExcludedIP(ip []string) error {
-	ret := _m.ctrl.Call(_m, "AddExcludedIP", ip)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockExcluderRecorder) AddExcludedIP(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddExcludedIP", arg0)
-}
-
 // Mock of Implementor interface
 type MockImplementor struct {
 	ctrl     *gomock.Controller

--- a/supervisor/proxy/supervisorproxy.go
+++ b/supervisor/proxy/supervisorproxy.go
@@ -53,7 +53,7 @@ func (s *ProxyInfo) Supervise(contextID string, puInfo *policy.PUInfo) error {
 			Identity:         puInfo.Policy.Identity(),
 			ReceiverRules:    puInfo.Policy.ReceiverRules(),
 			TransmitterRules: puInfo.Policy.TransmitterRules(),
-			ExcludedIPs:      s.ExcludedIPs,
+			ExcludedNetworks: puInfo.Policy.ExcludedNetworks(),
 			TriremeNetworks:  puInfo.Policy.TriremeNetworks(),
 		},
 	}

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -218,20 +218,6 @@ func (s *Config) doUpdatePU(contextID string, containerInfo *policy.PUInfo) erro
 	return nil
 }
 
-// AddExcludedIPs adds an exception for the destination parameter IP, allowing all the traffic.
-func (s *Config) AddExcludedIPs(ips []string) error {
-	// Remove everything and then apply the updatedSet.
-	if len(s.excludedIPs) > 0 {
-		if err := s.impl.RemoveExcludedIP(s.excludedIPs); err != nil {
-			log.WithFields(log.Fields{
-				"package": "supervisor",
-			}).Warn("Failed to clean up state while removing excluded IPs")
-		}
-	}
-	s.excludedIPs = ips
-	return s.impl.AddExcludedIP(ips)
-}
-
 func add(a, b interface{}) interface{} {
 	entry := a.(*cacheData)
 	entry.version += b.(int)

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -39,7 +39,7 @@ func createPUInfo() *policy.PUInfo {
 
 	runtime := policy.NewPURuntimeWithDefaults()
 	runtime.SetIPAddresses(ips)
-	plc := policy.NewPUPolicy("context", policy.Police, rules, rules, nil, nil, nil, nil, ips, []string{"172.17.0.0/24"}, nil)
+	plc := policy.NewPUPolicy("context", policy.Police, rules, rules, nil, nil, nil, nil, ips, []string{"172.17.0.0/24"}, []string{}, nil)
 
 	return policy.PUInfoFromPolicyAndRuntime("context", plc, runtime)
 

--- a/supervisor/supervisormock.go
+++ b/supervisor/supervisormock.go
@@ -28,7 +28,6 @@ type mockedMethods struct {
 // TestSupervisor is a test implementation for IptablesProvider
 type TestSupervisor interface {
 	Supervisor
-	Excluder
 	MockSupervise(t *testing.T, impl func(contextID string, puInfo *policy.PUInfo) error)
 	MockUnsupervise(t *testing.T, impl func(contextID string) error)
 	MockStart(t *testing.T, impl func() error)

--- a/trireme.go
+++ b/trireme.go
@@ -19,7 +19,6 @@ type trireme struct {
 	serverID    string
 	cache       cache.DataStore
 	supervisors map[constants.PUType]supervisor.Supervisor
-	excluders   map[constants.PUType]supervisor.Excluder
 	enforcers   map[constants.PUType]enforcer.PolicyEnforcer
 	resolver    PolicyResolver
 	collector   collector.EventCollector
@@ -28,13 +27,12 @@ type trireme struct {
 }
 
 // NewTrireme returns a reference to the trireme object based on the parameter subelements.
-func NewTrireme(serverID string, resolver PolicyResolver, supervisors map[constants.PUType]supervisor.Supervisor, excluders map[constants.PUType]supervisor.Excluder, enforcers map[constants.PUType]enforcer.PolicyEnforcer, eventCollector collector.EventCollector) Trireme {
+func NewTrireme(serverID string, resolver PolicyResolver, supervisors map[constants.PUType]supervisor.Supervisor, enforcers map[constants.PUType]enforcer.PolicyEnforcer, eventCollector collector.EventCollector) Trireme {
 
 	trireme := &trireme{
 		serverID:    serverID,
 		cache:       cache.NewCache(),
 		supervisors: supervisors,
-		excluders:   excluders,
 		enforcers:   enforcers,
 		resolver:    resolver,
 		collector:   eventCollector,
@@ -432,16 +430,6 @@ func (t *trireme) Supervisor(kind constants.PUType) supervisor.Supervisor {
 		return s
 	}
 
-	return nil
-}
-
-// AddExcludedIpList  pushes the list of excluded IP to all supervisors in the system
-func (t *trireme) AddExcludedIPList(ipList []string) error {
-	for _, excluder := range t.excluders {
-		if err := excluder.AddExcludedIPs(ipList); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/trireme_test.go
+++ b/trireme_test.go
@@ -12,16 +12,15 @@ import (
 	"github.com/aporeto-inc/trireme/supervisor"
 )
 
-func createMocks() (TestPolicyResolver, map[constants.PUType]supervisor.Supervisor, map[constants.PUType]supervisor.Excluder, map[constants.PUType]enforcer.PolicyEnforcer, monitor.TestMonitor, collector.EventCollector) {
+func createMocks() (TestPolicyResolver, map[constants.PUType]supervisor.Supervisor, map[constants.PUType]enforcer.PolicyEnforcer, monitor.TestMonitor, collector.EventCollector) {
 	tresolver := NewTestPolicyResolver()
 	s := supervisor.NewTestSupervisor()
 	tsupervisor := map[constants.PUType]supervisor.Supervisor{constants.ContainerPU: s}
-	texcluder := map[constants.PUType]supervisor.Excluder{constants.ContainerPU: s}
 
 	tenforcer := map[constants.PUType]enforcer.PolicyEnforcer{constants.ContainerPU: enforcer.NewTestPolicyEnforcer()}
 	tmonitor := monitor.NewTestMonitor()
 	tcollector := &collector.DefaultCollector{}
-	return tresolver, tsupervisor, texcluder, tenforcer, tmonitor, tcollector
+	return tresolver, tsupervisor, tenforcer, tmonitor, tcollector
 }
 
 func doTestCreate(t *testing.T, trireme Trireme, tresolver TestPolicyResolver, tsupervisor supervisor.TestSupervisor, tenforcer enforcer.TestPolicyEnforcer, tmonitor monitor.TestMonitor, id string, runtime *policy.PURuntime) {
@@ -41,7 +40,7 @@ func doTestCreate(t *testing.T, trireme Trireme, tresolver TestPolicyResolver, t
 		}
 
 		ipaddrs := policy.NewIPMap(map[string]string{policy.DefaultNamespace: "127.0.0.1"})
-		tpolicy := policy.NewPUPolicy("SomeId", policy.Police, nil, nil, nil, nil, nil, nil, ipaddrs, []string{"172.17.0.0/24"}, nil)
+		tpolicy := policy.NewPUPolicy("SomeId", policy.Police, nil, nil, nil, nil, nil, nil, ipaddrs, []string{"172.17.0.0/24"}, []string{}, nil)
 		resolverCount++
 		return tpolicy, nil
 	})
@@ -220,8 +219,8 @@ func doTestUpdate(t *testing.T, trireme Trireme, tresolver TestPolicyResolver, t
 }
 
 func TestSimpleCreate(t *testing.T) {
-	tresolver, tsupervisor, texcluder, tenforcer, tmonitor, tcollector := createMocks()
-	trireme := NewTrireme("serverID", tresolver, tsupervisor, texcluder, tenforcer, tcollector)
+	tresolver, tsupervisor, tenforcer, tmonitor, tcollector := createMocks()
+	trireme := NewTrireme("serverID", tresolver, tsupervisor, tenforcer, tcollector)
 	if err := trireme.Start(); err != nil {
 		t.Errorf("Failed to start trireme")
 	}
@@ -232,8 +231,8 @@ func TestSimpleCreate(t *testing.T) {
 }
 
 func TestSimpleDelete(t *testing.T) {
-	tresolver, tsupervisor, texcluder, tenforcer, tmonitor, tcollector := createMocks()
-	trireme := NewTrireme("serverID", tresolver, tsupervisor, texcluder, tenforcer, tcollector)
+	tresolver, tsupervisor, tenforcer, tmonitor, tcollector := createMocks()
+	trireme := NewTrireme("serverID", tresolver, tsupervisor, tenforcer, tcollector)
 	if err := trireme.Start(); err != nil {
 		t.Errorf("Failed to start trireme")
 	}
@@ -244,8 +243,8 @@ func TestSimpleDelete(t *testing.T) {
 }
 
 func TestCreateDelete(t *testing.T) {
-	tresolver, tsupervisor, texcluder, tenforcer, tmonitor, tcollector := createMocks()
-	trireme := NewTrireme("serverID", tresolver, tsupervisor, texcluder, tenforcer, tcollector)
+	tresolver, tsupervisor, tenforcer, tmonitor, tcollector := createMocks()
+	trireme := NewTrireme("serverID", tresolver, tsupervisor, tenforcer, tcollector)
 	if err := trireme.Start(); err != nil {
 		t.Errorf("Failed to start trireme")
 	}
@@ -257,8 +256,8 @@ func TestCreateDelete(t *testing.T) {
 }
 
 func TestSimpleUpdate(t *testing.T) {
-	tresolver, tsupervisor, texcluder, tenforcer, tmonitor, tcollector := createMocks()
-	trireme := NewTrireme("serverID", tresolver, tsupervisor, texcluder, tenforcer, tcollector)
+	tresolver, tsupervisor, tenforcer, tmonitor, tcollector := createMocks()
+	trireme := NewTrireme("serverID", tresolver, tsupervisor, tenforcer, tcollector)
 	if err := trireme.Start(); err != nil {
 		t.Errorf("Failed to start trireme")
 	}
@@ -274,13 +273,13 @@ func TestSimpleUpdate(t *testing.T) {
 	// Generate a new Policy ...
 	ipl := policy.NewIPMap(map[string]string{policy.DefaultNamespace: "127.0.0.1"})
 	tagsMap := policy.NewTagsMap(map[string]string{enforcer.TransmitterLabel: contextID})
-	newPolicy := policy.NewPUPolicy("", policy.Police, nil, nil, nil, nil, tagsMap, nil, ipl, []string{"172.17.0.0/24"}, nil)
+	newPolicy := policy.NewPUPolicy("", policy.Police, nil, nil, nil, nil, tagsMap, nil, ipl, []string{"172.17.0.0/24"}, []string{}, nil)
 	doTestUpdate(t, trireme, tresolver, tsupervisor[constants.ContainerPU].(supervisor.TestSupervisor), tenforcer[constants.ContainerPU].(enforcer.TestPolicyEnforcer), tmonitor, contextID, runtime, newPolicy)
 }
 
 func TestCache(t *testing.T) {
-	tresolver, tsupervisor, texcluder, tenforcer, tmonitor, tcollector := createMocks()
-	trireme := NewTrireme("serverID", tresolver, tsupervisor, texcluder, tenforcer, tcollector)
+	tresolver, tsupervisor, tenforcer, tmonitor, tcollector := createMocks()
+	trireme := NewTrireme("serverID", tresolver, tsupervisor, tenforcer, tcollector)
 	if err := trireme.Start(); err != nil {
 		t.Errorf("Failed to start trireme")
 	}
@@ -311,8 +310,8 @@ func TestCache(t *testing.T) {
 }
 
 func TestStop(t *testing.T) {
-	tresolver, tsupervisor, texcluder, tenforcer, tmonitor, tcollector := createMocks()
-	trireme := NewTrireme("serverID", tresolver, tsupervisor, texcluder, tenforcer, tcollector)
+	tresolver, tsupervisor, tenforcer, tmonitor, tcollector := createMocks()
+	trireme := NewTrireme("serverID", tresolver, tsupervisor, tenforcer, tcollector)
 	if err := trireme.Start(); err != nil {
 		t.Errorf("Failed to start trireme")
 	}
@@ -329,18 +328,6 @@ func TestStop(t *testing.T) {
 		t.Errorf("Failed to start trireme")
 	}
 	doTestCreate(t, trireme, tresolver, tsupervisor[constants.ContainerPU].(supervisor.TestSupervisor), tenforcer[constants.ContainerPU].(enforcer.TestPolicyEnforcer), tmonitor, contextID, runtime)
-}
-
-func TestAddExcludedIP(t *testing.T) {
-	tresolver, tsupervisor, texcluder, tenforcer, _, tcollector := createMocks()
-	trireme := NewTrireme("serverID", tresolver, tsupervisor, texcluder, tenforcer, tcollector)
-	if err := trireme.Start(); err != nil {
-		t.Errorf("Failed to start trireme")
-	}
-
-	if err := trireme.AddExcludedIPList([]string{"10.10.10.1"}); err != nil {
-		t.Errorf("Failed to add exclusion IPs")
-	}
 }
 
 func TestTransmitterLabel(t *testing.T) {

--- a/utils/common/common.go
+++ b/utils/common/common.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aporeto-inc/trireme/enforcer"
 	"github.com/aporeto-inc/trireme/monitor"
 	"github.com/aporeto-inc/trireme/monitor/dockermonitor"
-	"github.com/aporeto-inc/trireme/supervisor"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -20,7 +19,7 @@ var (
 )
 
 // TriremeWithPKI is a helper method to created a PKI implementation of Trireme
-func TriremeWithPKI(keyFile, certFile, caCertFile string, networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool) (trireme.Trireme, monitor.Monitor, supervisor.Excluder) {
+func TriremeWithPKI(keyFile, certFile, caCertFile string, networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool) (trireme.Trireme, monitor.Monitor) {
 
 	// Load client cert
 	certPEM, err := ioutil.ReadFile(certFile)
@@ -47,17 +46,17 @@ func TriremeWithPKI(keyFile, certFile, caCertFile string, networks []string, ext
 
 	policyEngine := NewCustomPolicyResolver(networks)
 
-	t, m, e, p := configurator.NewPKITriremeWithDockerMonitor("Server1", policyEngine, ExternalProcessor, nil, false, keyPEM, certPEM, caCertPEM, *extractor, remoteEnforcer)
+	t, m, p := configurator.NewPKITriremeWithDockerMonitor("Server1", policyEngine, ExternalProcessor, nil, false, keyPEM, certPEM, caCertPEM, *extractor, remoteEnforcer)
 
 	if err := p.PublicKeyAdd("Server1", certPEM); err != nil {
 		log.Fatal(err)
 	}
 
-	return t, m, e
+	return t, m
 }
 
 //TriremeWithPSK is a helper method to created a PSK implementation of Trireme
-func TriremeWithPSK(networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool) (trireme.Trireme, monitor.Monitor, supervisor.Excluder) {
+func TriremeWithPSK(networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool) (trireme.Trireme, monitor.Monitor) {
 
 	policyEngine := NewCustomPolicyResolver(networks)
 
@@ -66,7 +65,7 @@ func TriremeWithPSK(networks []string, extractor *dockermonitor.DockerMetadataEx
 }
 
 //HybridTriremeWithPSK is a helper method to created a PSK implementation of Trireme
-func HybridTriremeWithPSK(networks []string, extractor *dockermonitor.DockerMetadataExtractor) (trireme.Trireme, monitor.Monitor, monitor.Monitor, supervisor.Excluder) {
+func HybridTriremeWithPSK(networks []string, extractor *dockermonitor.DockerMetadataExtractor) (trireme.Trireme, monitor.Monitor, monitor.Monitor) {
 
 	policyEngine := NewCustomPolicyResolver(networks)
 

--- a/utils/common/handler.go
+++ b/utils/common/handler.go
@@ -93,13 +93,13 @@ func processDaemonArgs(arguments map[string]interface{}, processor enforcer.Pack
 				"cert-file":    certFile,
 				"ca-cert-file": caCertFile,
 			}).Info("Setting up trireme with PKI")
-			t, m, _ = TriremeWithPKI(keyFile, certFile, caCertFile, targetNetworks, &customExtractor, remote)
+			t, m = TriremeWithPKI(keyFile, certFile, caCertFile, targetNetworks, &customExtractor, remote)
 		} else {
 			log.Info("Setting up trireme with PSK")
-			t, m, _ = TriremeWithPSK(targetNetworks, &customExtractor, remote)
+			t, m = TriremeWithPSK(targetNetworks, &customExtractor, remote)
 		}
 	} else { // Hybrid mode
-		t, m, rm, _ = HybridTriremeWithPSK(targetNetworks, &customExtractor)
+		t, m, rm = HybridTriremeWithPSK(targetNetworks, &customExtractor)
 		if rm == nil {
 			log.Fatalln("Failed to create remote monitor for hybrid")
 		}

--- a/utils/common/policy.go
+++ b/utils/common/policy.go
@@ -84,7 +84,9 @@ func (p *CustomPolicyResolver) ResolvePolicy(context string, runtimeInfo policy.
 
 	annotations := runtimeInfo.Tags()
 
-	containerPolicyInfo := policy.NewPUPolicy(context, policy.Police, ingress, egress, nil, tagSelectors, identity, annotations, ipl, p.triremeNets, nil)
+	excluded := []string{"172.17.0.1/32"}
+
+	containerPolicyInfo := policy.NewPUPolicy(context, policy.Police, ingress, egress, nil, tagSelectors, identity, annotations, ipl, p.triremeNets, excluded, nil)
 
 	return containerPolicyInfo, nil
 }


### PR DESCRIPTION
With this PR, the exclusions interface of Trireme changes and any excluded networks are provided 
as part of the policy resolution. This both simplifies the design and allows the dynamic update of
the networks that need to be excluded.