### PR TITLE
Remoteenforcer host

### DIFF
--- a/monitor/linuxmonitor/cgnetcls/cgnetcls.go
+++ b/monitor/linuxmonitor/cgnetcls/cgnetcls.go
@@ -27,7 +27,7 @@ const (
 	// PortTag is the tag for a port
 	PortTag = "@usr:port"
 
-	basePath             = "/var/run/aporeto/cgroup"
+	basePath             = "/sys/fs/cgroup/net_cls"
 	markFile             = "/net_cls.classid"
 	procs                = "/cgroup.procs"
 	releaseAgentConfFile = "/release_agent"

--- a/monitor/linuxmonitor/cgnetcls/cgnetcls.go
+++ b/monitor/linuxmonitor/cgnetcls/cgnetcls.go
@@ -27,7 +27,7 @@ const (
 	// PortTag is the tag for a port
 	PortTag = "@usr:port"
 
-	basePath             = "/sys/fs/cgroup/net_cls"
+	basePath             = "/var/run/aporeto/cgroup"
 	markFile             = "/net_cls.classid"
 	procs                = "/cgroup.procs"
 	releaseAgentConfFile = "/release_agent"


### PR DESCRIPTION
Code to ensure that we don't launch remote enforcer in host network namespace. 
Simple check to see if the container network namespace is not the same as init process. 
