### PR TITLE
NEW: DockerMonitor No-Kill option

### DIFF
--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -241,6 +241,7 @@ func NewPSKTriremeWithDockerMonitor(
 	key []byte,
 	dockerMetadataExtractor dockermonitor.DockerMetadataExtractor,
 	remoteEnforcer bool,
+	killContainerError bool,
 ) (trireme.Trireme, monitor.Monitor) {
 
 	if eventCollector == nil {
@@ -279,7 +280,8 @@ func NewPSKTriremeWithDockerMonitor(
 		dockerMetadataExtractor,
 		eventCollector,
 		syncAtStart,
-		nil)
+		nil,
+		killContainerError)
 
 	return triremeInstance, monitorInstance
 
@@ -300,6 +302,7 @@ func NewPKITriremeWithDockerMonitor(
 	caCertPEM []byte,
 	dockerMetadataExtractor dockermonitor.DockerMetadataExtractor,
 	remoteEnforcer bool,
+	killContainerError bool,
 ) (trireme.Trireme, monitor.Monitor, enforcer.PublicKeyAdder) {
 
 	if eventCollector == nil {
@@ -338,7 +341,8 @@ func NewPKITriremeWithDockerMonitor(
 		dockerMetadataExtractor,
 		eventCollector,
 		syncAtStart,
-		nil)
+		nil,
+		killContainerError)
 
 	return triremeInstance, monitorInstance, publicKeyAdder
 
@@ -355,6 +359,7 @@ func NewPSKHybridTriremeWithMonitor(
 	syncAtStart bool,
 	key []byte,
 	dockerMetadataExtractor dockermonitor.DockerMetadataExtractor,
+	killContainerError bool,
 ) (trireme.Trireme, monitor.Monitor, monitor.Monitor) {
 
 	if eventCollector == nil {
@@ -382,6 +387,7 @@ func NewPSKHybridTriremeWithMonitor(
 		eventCollector,
 		syncAtStart,
 		nil,
+		killContainerError,
 	)
 	// use rpcmonitor no need to return it since no other consumer for it
 	rpcmon, err := rpcmonitor.NewRPCMonitor(

--- a/monitor/dockermonitor/docker.go
+++ b/monitor/dockermonitor/docker.go
@@ -125,11 +125,11 @@ type dockerMonitor struct {
 	stoplistener       chan bool
 	syncAtStart        bool
 	syncHandler        monitor.SynchronizationHandler
-	// killContainerError if enabled kills the container if a policy setting resulted in an error.
-	killContainerError bool
 
 	collector collector.EventCollector
 	puHandler monitor.ProcessingUnitsHandler
+	// killContainerError if enabled kills the container if a policy setting resulted in an error.
+	killContainerError bool
 }
 
 // NewDockerMonitor returns a pointer to a DockerMonitor initialized with the given

--- a/monitor/dockermonitor/docker.go
+++ b/monitor/dockermonitor/docker.go
@@ -146,6 +146,7 @@ func NewDockerMonitor(
 	l collector.EventCollector,
 	syncAtStart bool,
 	s monitor.SynchronizationHandler,
+	killContainerError bool,
 ) monitor.Monitor {
 
 	cli, err := initDockerClient(socketType, socketAddress)
@@ -168,6 +169,7 @@ func NewDockerMonitor(
 		dockerClient:       cli,
 		syncAtStart:        syncAtStart,
 		syncHandler:        s,
+		killContainerError: killContainerError,
 	}
 
 	// Add handlers for the events that we know how to process

--- a/monitor/dockermonitor/docker.go
+++ b/monitor/dockermonitor/docker.go
@@ -123,13 +123,13 @@ type dockerMonitor struct {
 	eventnotifications chan *events.Message
 	stopprocessor      chan bool
 	stoplistener       chan bool
-	syncAtStart        bool
 	syncHandler        monitor.SynchronizationHandler
 
 	collector collector.EventCollector
 	puHandler monitor.ProcessingUnitsHandler
 	// killContainerError if enabled kills the container if a policy setting resulted in an error.
 	killContainerError bool
+	syncAtStart        bool
 }
 
 // NewDockerMonitor returns a pointer to a DockerMonitor initialized with the given

--- a/utils/common/common.go
+++ b/utils/common/common.go
@@ -19,7 +19,7 @@ var (
 )
 
 // TriremeWithPKI is a helper method to created a PKI implementation of Trireme
-func TriremeWithPKI(keyFile, certFile, caCertFile string, networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool) (trireme.Trireme, monitor.Monitor) {
+func TriremeWithPKI(keyFile, certFile, caCertFile string, networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool, killContainerError bool) (trireme.Trireme, monitor.Monitor) {
 
 	// Load client cert
 	certPEM, err := ioutil.ReadFile(certFile)
@@ -46,7 +46,7 @@ func TriremeWithPKI(keyFile, certFile, caCertFile string, networks []string, ext
 
 	policyEngine := NewCustomPolicyResolver(networks)
 
-	t, m, p := configurator.NewPKITriremeWithDockerMonitor("Server1", policyEngine, ExternalProcessor, nil, false, keyPEM, certPEM, caCertPEM, *extractor, remoteEnforcer)
+	t, m, p := configurator.NewPKITriremeWithDockerMonitor("Server1", policyEngine, ExternalProcessor, nil, false, keyPEM, certPEM, caCertPEM, *extractor, remoteEnforcer, killContainerError)
 
 	if err := p.PublicKeyAdd("Server1", certPEM); err != nil {
 		log.Fatal(err)
@@ -56,20 +56,20 @@ func TriremeWithPKI(keyFile, certFile, caCertFile string, networks []string, ext
 }
 
 //TriremeWithPSK is a helper method to created a PSK implementation of Trireme
-func TriremeWithPSK(networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool) (trireme.Trireme, monitor.Monitor) {
+func TriremeWithPSK(networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool, killContainerError bool) (trireme.Trireme, monitor.Monitor) {
 
 	policyEngine := NewCustomPolicyResolver(networks)
 
 	// Use this if you want a pre-shared key implementation
-	return configurator.NewPSKTriremeWithDockerMonitor("Server1", policyEngine, ExternalProcessor, nil, false, []byte("THIS IS A BAD PASSWORD"), *extractor, remoteEnforcer)
+	return configurator.NewPSKTriremeWithDockerMonitor("Server1", policyEngine, ExternalProcessor, nil, false, []byte("THIS IS A BAD PASSWORD"), *extractor, remoteEnforcer, killContainerError)
 }
 
 //HybridTriremeWithPSK is a helper method to created a PSK implementation of Trireme
-func HybridTriremeWithPSK(networks []string, extractor *dockermonitor.DockerMetadataExtractor) (trireme.Trireme, monitor.Monitor, monitor.Monitor) {
+func HybridTriremeWithPSK(networks []string, extractor *dockermonitor.DockerMetadataExtractor, killContainerError bool) (trireme.Trireme, monitor.Monitor, monitor.Monitor) {
 
 	policyEngine := NewCustomPolicyResolver(networks)
 
 	pass := []byte("THIS IS A BAD PASSWORD")
 	// Use this if you want a pre-shared key implementation
-	return configurator.NewPSKHybridTriremeWithMonitor("Server1", policyEngine, ExternalProcessor, nil, false, pass, *extractor)
+	return configurator.NewPSKHybridTriremeWithMonitor("Server1", policyEngine, ExternalProcessor, nil, false, pass, *extractor, killContainerError)
 }

--- a/utils/common/handler.go
+++ b/utils/common/handler.go
@@ -16,6 +16,9 @@ import (
 	"github.com/aporeto-inc/trireme/processmon"
 )
 
+// KillContainerOnError defines if the Container is getting killed if the policy Application resulted in an error
+const KillContainerOnError = true
+
 // ProcessArgs handles all commands options for trireme
 func ProcessArgs(arguments map[string]interface{}, processor enforcer.PacketProcessor, logLevel log.Level) (err error) {
 
@@ -93,13 +96,13 @@ func processDaemonArgs(arguments map[string]interface{}, processor enforcer.Pack
 				"cert-file":    certFile,
 				"ca-cert-file": caCertFile,
 			}).Info("Setting up trireme with PKI")
-			t, m = TriremeWithPKI(keyFile, certFile, caCertFile, targetNetworks, &customExtractor, remote)
+			t, m = TriremeWithPKI(keyFile, certFile, caCertFile, targetNetworks, &customExtractor, remote, KillContainerOnError)
 		} else {
 			log.Info("Setting up trireme with PSK")
-			t, m = TriremeWithPSK(targetNetworks, &customExtractor, remote)
+			t, m = TriremeWithPSK(targetNetworks, &customExtractor, remote, KillContainerOnError)
 		}
 	} else { // Hybrid mode
-		t, m, rm = HybridTriremeWithPSK(targetNetworks, &customExtractor)
+		t, m, rm = HybridTriremeWithPSK(targetNetworks, &customExtractor, KillContainerOnError)
 		if rm == nil {
 			log.Fatalln("Failed to create remote monitor for hybrid")
 		}


### PR DESCRIPTION
This PR adds an option on the DockerMonitor so that it can be spawned with a no-kill option in case the policy setup failed.

The way it works is in case Trireme returns an error for handling the start event of the container, the container isn't killed and continues to run. It is useful in environment such as Kubernetes where killing the containers might destroy the node completely