### PR TITLE
Fix flow collection issues

### DIFF
--- a/cmd/remoteenforcer/remotecollector.go
+++ b/cmd/remoteenforcer/remotecollector.go
@@ -35,6 +35,7 @@ func (c *CollectorImpl) CollectFlowEvent(record *collector.FlowRecord) {
 	}
 
 	c.Flows[hash] = record
+	c.Flows[hash].Tags = c.Flows[hash].Tags.Clone()
 }
 
 //CollectContainerEvent exported

--- a/cmd/remoteenforcer/remotecollector_test.go
+++ b/cmd/remoteenforcer/remotecollector_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/aporeto-inc/trireme/collector"
+	"github.com/aporeto-inc/trireme/policy"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -32,6 +33,7 @@ func TestCollectFlowEvent(t *testing.T) {
 				DestinationIP:   "2.2.2.2",
 				DestinationPort: 80,
 				Count:           1,
+				Tags:            &policy.TagsMap{},
 			}
 			c.CollectFlowEvent(r)
 
@@ -50,6 +52,7 @@ func TestCollectFlowEvent(t *testing.T) {
 					DestinationIP:   "2.2.2.2",
 					DestinationPort: 80,
 					Count:           10,
+					Tags:            &policy.TagsMap{},
 				}
 				c.CollectFlowEvent(r)
 				Convey("The flow should be in the cache", func() {
@@ -68,6 +71,7 @@ func TestCollectFlowEvent(t *testing.T) {
 					DestinationIP:   "4.4.4.4",
 					DestinationPort: 80,
 					Count:           33,
+					Tags:            &policy.TagsMap{},
 				}
 				c.CollectFlowEvent(r)
 				Convey("The flow should be in the cache", func() {

--- a/enforcer/datapath_tcp.go
+++ b/enforcer/datapath_tcp.go
@@ -776,7 +776,7 @@ func (d *datapathEnforcer) processNetworkAckPacket(context *PUContext, tcpPacket
 		}
 
 		//We have  connection established lets remove the destinationport cache entry
-		d.destinationPortCache.Remove(tcpPacket.DestinationPortHash(packet.PacketTypeNetwork))
+		d.destinationPortCache.Remove(tcpPacket.DestinationPortHash(packet.PacketTypeNetwork)) //nolint
 
 		// Packet can be forwarded
 		return nil, nil


### PR DESCRIPTION
Fix two issues related to the flow collection:

1. A race condition where a flow record can change while cached.
2. A invalid drop message for a packet that is accepted by policy.