### PR TITLE
Fix RPC Sync 

### DIFF
--- a/monitor/linuxmonitor/cgnetcls/cgnetcls.go
+++ b/monitor/linuxmonitor/cgnetcls/cgnetcls.go
@@ -229,6 +229,7 @@ func MarkVal() uint64 {
 func ListCgroupProcesses(cgroupname string) ([]string, error) {
 
 	_, err := os.Stat(basePath + TriremeBasePath + cgroupname)
+
 	if os.IsNotExist(err) {
 		return []string{}, errors.New("Cgroup does not exist")
 	}
@@ -239,9 +240,7 @@ func ListCgroupProcesses(cgroupname string) ([]string, error) {
 	}
 
 	procs := []string{}
-	if len(procs) == 0 {
-		return procs, nil
-	}
+
 	for _, line := range strings.Split(string(data), "\n") {
 		procs = append(procs, string(line))
 	}

--- a/monitor/linuxmonitor/cgnetcls/cgnetcls.go
+++ b/monitor/linuxmonitor/cgnetcls/cgnetcls.go
@@ -242,7 +242,10 @@ func ListCgroupProcesses(cgroupname string) ([]string, error) {
 	procs := []string{}
 
 	for _, line := range strings.Split(string(data), "\n") {
-		procs = append(procs, string(line))
+		if len(line) > 0 {
+			procs = append(procs, string(line))
+		}
 	}
+
 	return procs, nil
 }


### PR DESCRIPTION
Fixing the problem of an empty tasks file, that was giving an list of greater than one. As a result if a process was deleted while Trireme was not active, the process was never cleared up.