### PR TITLE
Fix kill conditions

### DIFF
--- a/cmd/remoteenforcer/remoteenforcer_linux.go
+++ b/cmd/remoteenforcer/remoteenforcer_linux.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+
 	"golang.org/x/sys/unix"
 
 	"go.uber.org/zap"
@@ -389,7 +390,7 @@ func LaunchRemoteEnforcer(service enforcer.PacketProcessor) error {
 	flag := unix.SIGHUP
 
 	if err := unix.Prctl(unix.PR_SET_PDEATHSIG, uintptr(flag), 0, 0, 0); err != nil {
-	    return fmt.Errorf("Unable to set termination process")
+		return fmt.Errorf("Unable to set termination process")
 	}
 
 	rpchdl := rpcwrapper.NewRPCServer()

--- a/processmon/processmon.go
+++ b/processmon/processmon.go
@@ -152,12 +152,15 @@ func (p *ProcessMon) KillProcess(contextID string) {
 	select {
 	case kerr := <-c:
 		if kerr != nil {
-			if perr := s.(*processInfo).process.Kill(); perr != nil {
-				zap.L().Debug("Process is already dead",
-					zap.String("Remote error", kerr.Error()),
-					zap.String("Kill error", perr.Error()))
-			}
+			zap.L().Debug("Failed to stop gracefully",
+				zap.String("Remote error", kerr.Error()))
 		}
+
+		if perr := s.(*processInfo).process.Kill(); perr != nil {
+			zap.L().Debug("Process is already dead",
+				zap.String("Kill error", perr.Error()))
+		}
+
 	case <-time.After(5 * time.Second):
 		if perr := s.(*processInfo).process.Kill(); perr != nil {
 			zap.L().Info("Time out while killing process ",


### PR DESCRIPTION
With this PR we improve in several of the termination/kill conditions. The expected behavior:

- if the parent process is terminated gracefully, all the remote enforcers exit and clean state.

- if the parent process is killed with -9 (or crashes), all the remote enforcers will be terminated as well so that when the parent recovers, they will recover as well.

If the parent dies with -9 or crash, and the remotes are not killed, they will not release the NFQUEUEs and it becomes very hard to recover. This can be potentially solved by killing the 
remotes when the parent recovers.