### PR TITLE
Use compact token to communicate the public key

### DIFF
--- a/cmd/remoteenforcer/remoteenforcer_linux.go
+++ b/cmd/remoteenforcer/remoteenforcer_linux.go
@@ -143,7 +143,7 @@ func (s *Server) InitEnforcer(req rpcwrapper.Request, resp *rpcwrapper.Response)
 	payload := req.Payload.(rpcwrapper.InitRequestPayload)
 	switch payload.SecretType {
 	case tokens.PKIType :
-		//PKI params
+		// PKI params
 		secrets := tokens.NewPKISecrets(payload.PrivatePEM, payload.PublicPEM, payload.CAPEM, map[string]*ecdsa.PublicKey{})
 		s.Enforcer = enforcer.New(
 			payload.MutualAuth,
@@ -157,7 +157,7 @@ func (s *Server) InitEnforcer(req rpcwrapper.Request, resp *rpcwrapper.Response)
 			s.procMountPoint,
 		)
 	case tokens.PSKType:
-		//PSK params
+		// PSK params
 		secrets := tokens.NewPSKSecrets(payload.PrivatePEM)
 		s.Enforcer = enforcer.New(
 			payload.MutualAuth,
@@ -171,8 +171,7 @@ func (s *Server) InitEnforcer(req rpcwrapper.Request, resp *rpcwrapper.Response)
 			s.procMountPoint,
 		)
 	case tokens.PKICompactType:
-		//PKI Parameters
-		fmt.Println("Setting REMOTE with COMPACT PKI ")
+		// Compact PKI Parameters
 		secrets, err  := tokens.NewCompactPKI(payload.PrivatePEM, payload.PublicPEM, payload.CAPEM, payload.Token)
 		if err != nil {
 			return fmt.Errorf("Failed to initialize secrets")

--- a/cmd/remoteenforcer/remoteenforcer_linux.go
+++ b/cmd/remoteenforcer/remoteenforcer_linux.go
@@ -142,7 +142,7 @@ func (s *Server) InitEnforcer(req rpcwrapper.Request, resp *rpcwrapper.Response)
 
 	payload := req.Payload.(rpcwrapper.InitRequestPayload)
 	switch payload.SecretType {
-	case tokens.PKIType :
+	case tokens.PKIType:
 		// PKI params
 		secrets := tokens.NewPKISecrets(payload.PrivatePEM, payload.PublicPEM, payload.CAPEM, map[string]*ecdsa.PublicKey{})
 		s.Enforcer = enforcer.New(
@@ -172,7 +172,7 @@ func (s *Server) InitEnforcer(req rpcwrapper.Request, resp *rpcwrapper.Response)
 		)
 	case tokens.PKICompactType:
 		// Compact PKI Parameters
-		secrets, err  := tokens.NewCompactPKI(payload.PrivatePEM, payload.PublicPEM, payload.CAPEM, payload.Token)
+		secrets, err := tokens.NewCompactPKI(payload.PrivatePEM, payload.PublicPEM, payload.CAPEM, payload.Token)
 		if err != nil {
 			return fmt.Errorf("Failed to initialize secrets")
 		}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -125,14 +125,7 @@ func LoadEllipticCurveKey(keyPEM []byte) (*ecdsa.PrivateKey, error) {
 // It must be provided with the a CertPool
 func LoadAndVerifyCertificate(certPEM []byte, roots *x509.CertPool) (*x509.Certificate, error) {
 
-	// Decode the certificate
-	certBlock, _ := pem.Decode(certPEM)
-	if certBlock == nil {
-		return nil, fmt.Errorf("Failed to decode PEM block")
-	}
-
-	// Create the certificate structure
-	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	cert, err := LoadCertificate(certPEM)
 	if err != nil {
 		return nil, err
 	}
@@ -171,4 +164,24 @@ func LoadAndVerifyECSecrets(keyPEM, certPEM, caCertPEM []byte) (key *ecdsa.Priva
 
 	return key, cert, rootCertPool, nil
 
+}
+
+// LoadCertificate loads a certificate from a PEM file without verifying
+// Should only be used for loading a root CA certificate. It will only read
+// the first certificate
+func LoadCertificate(certPEM []byte) (*x509.Certificate, error) {
+
+	// Decode the certificate
+	certBlock, _ := pem.Decode(certPEM)
+	if certBlock == nil {
+		return nil, fmt.Errorf("Failed to decode PEM block")
+	}
+
+	// Create the certificate structure
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return cert, nil
 }

--- a/enforcer/proxy/enforcerproxy.go
+++ b/enforcer/proxy/enforcerproxy.go
@@ -44,6 +44,7 @@ var ErrInitFailed = errors.New("Failed remote Init")
 type proxyInfo struct {
 	MutualAuth        bool
 	Secrets           tokens.Secrets
+	publicKeyToken    []byte
 	serverID          string
 	validity          time.Duration
 	prochdl           processmon.ProcessManager
@@ -70,6 +71,10 @@ func (s *proxyInfo) InitRemoteEnforcer(contextID string) error {
 			PublicPEM:  s.Secrets.(keyPEM).TransmittedPEM(),
 			PrivatePEM: s.Secrets.(keyPEM).EncodingPEM(),
 		},
+	}
+
+	if s.Secrets.Type() == tokens.PKICompactType {
+		request.Payload.(*rpcwrapper.InitRequestPayload).Token = s.Secrets.TransmittedKey()
 	}
 
 	if err := s.rpchdl.RemoteCall(contextID, "Server.InitEnforcer", request, resp); err != nil {

--- a/enforcer/proxy/enforcerproxy.go
+++ b/enforcer/proxy/enforcerproxy.go
@@ -44,7 +44,6 @@ var ErrInitFailed = errors.New("Failed remote Init")
 type proxyInfo struct {
 	MutualAuth        bool
 	Secrets           tokens.Secrets
-	publicKeyToken    []byte
 	serverID          string
 	validity          time.Duration
 	prochdl           processmon.ProcessManager

--- a/enforcer/utils/pkiverifier/pkiverifier.go
+++ b/enforcer/utils/pkiverifier/pkiverifier.go
@@ -1,0 +1,111 @@
+package pkiverifier
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/x509"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	"go.uber.org/zap"
+
+	"github.com/aporeto-inc/trireme/cache"
+)
+
+const (
+	// defaultValidity is the default cache validity in seconds
+	defaultValidity = 1
+)
+
+// VerifierClaims captures all the clains of the verifier that is basically the public key
+type VerifierClaims struct {
+	X *big.Int
+	Y *big.Int
+	jwt.StandardClaims
+}
+
+// PKIConfiguration is the configuration of the verifier
+type PKIConfiguration struct {
+	publicKey  *ecdsa.PublicKey
+	privateKey *ecdsa.PrivateKey
+	signMethod jwt.SigningMethod
+	keycache   cache.DataStore
+	validity   time.Duration
+}
+
+// NewConfig initializes a new signer structure
+func NewConfig(publicKey *ecdsa.PublicKey, privateKey *ecdsa.PrivateKey, cacheValiditiy time.Duration) *PKIConfiguration {
+
+	validity := defaultValidity * time.Second
+	if cacheValiditiy > 0 {
+		validity = cacheValiditiy
+	}
+
+	return &PKIConfiguration{
+		publicKey:  publicKey,
+		privateKey: privateKey,
+		signMethod: jwt.SigningMethodES256,
+		keycache:   cache.NewCacheWithExpiration(validity),
+		validity:   validity,
+	}
+}
+
+// Verify verifies a token and returns the public key
+func (p *PKIConfiguration) Verify(token []byte) (*ecdsa.PublicKey, error) {
+
+	tokenString := string(token)
+
+	claims := &VerifierClaims{}
+
+	if pk, err := p.keycache.Get(tokenString); err == nil {
+		return pk.(*ecdsa.PublicKey), nil
+	}
+
+	// Parse the JWT token with the public key recovered
+	jwttoken, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+		return p.publicKey, nil
+	})
+
+	if err != nil || !jwttoken.Valid {
+		zap.L().Error("Failed to parse public key structure", zap.Error(err))
+		return nil, fmt.Errorf("error in token %v ", err.Error())
+	}
+
+	pk := KeyFromClaims(claims)
+
+	if time.Now().Add(p.validity).Unix() <= claims.ExpiresAt {
+		p.keycache.AddOrUpdate(tokenString, pk)
+	}
+
+	return pk, nil
+}
+
+// CreateTokenFromCertificate creates and signs a token
+func (p *PKIConfiguration) CreateTokenFromCertificate(cert *x509.Certificate) ([]byte, error) {
+
+	// Combine the application claims with the standard claims
+	claims := &VerifierClaims{
+		X: cert.PublicKey.(*ecdsa.PublicKey).X,
+		Y: cert.PublicKey.(*ecdsa.PublicKey).Y,
+	}
+	claims.ExpiresAt = cert.NotAfter.Unix()
+
+	// Create the token and sign with our key
+	strtoken, err := jwt.NewWithClaims(p.signMethod, claims).SignedString(p.privateKey)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return []byte(strtoken), nil
+}
+
+// KeyFromClaims creates the public key structure from the claims
+func KeyFromClaims(claims *VerifierClaims) *ecdsa.PublicKey {
+	return &ecdsa.PublicKey{
+		Curve: elliptic.P256(),
+		X:     claims.X,
+		Y:     claims.Y,
+	}
+}

--- a/enforcer/utils/pkiverifier/pkiverifier_test.go
+++ b/enforcer/utils/pkiverifier/pkiverifier_test.go
@@ -1,0 +1,137 @@
+package pkiverifier
+
+import (
+	"crypto/ecdsa"
+	"testing"
+	"time"
+
+	"github.com/aporeto-inc/trireme/crypto"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var (
+	keyPEM = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIPkiHqtH372JJdAG/IxJlE1gv03cdwa8Lhg2b3m/HmbyoAoGCCqGSM49
+AwEHoUQDQgAEAfAL+AfPj/DnxrU6tUkEyzEyCxnflOWxhouy1bdzhJ7vxMb1vQ31
+8ZbW/WvMN/ojIXqXYrEpISoojznj46w64w==
+-----END EC PRIVATE KEY-----`
+	caPool = `-----BEGIN CERTIFICATE-----
+MIIBhTCCASwCCQC8b53yGlcQazAKBggqhkjOPQQDAjBLMQswCQYDVQQGEwJVUzEL
+MAkGA1UECAwCQ0ExDDAKBgNVBAcMA1NKQzEQMA4GA1UECgwHVHJpcmVtZTEPMA0G
+A1UEAwwGdWJ1bnR1MB4XDTE2MDkyNzIyNDkwMFoXDTI2MDkyNTIyNDkwMFowSzEL
+MAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMQwwCgYDVQQHDANTSkMxEDAOBgNVBAoM
+B1RyaXJlbWUxDzANBgNVBAMMBnVidW50dTBZMBMGByqGSM49AgEGCCqGSM49AwEH
+A0IABJxneTUqhbtgEIwpKUUzwz3h92SqcOdIw3mfQkMjg3Vobvr6JKlpXYe9xhsN
+rygJmLhMAN9gjF9qM9ybdbe+m3owCgYIKoZIzj0EAwIDRwAwRAIgC1fVMqdBy/o3
+jNUje/Hx0fZF9VDyUK4ld+K/wF3QdK4CID1ONj/Kqinrq2OpjYdkgIjEPuXoOoR1
+tCym8dnq4wtH
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIB3jCCAYOgAwIBAgIJALsW7pyC2ERQMAoGCCqGSM49BAMCMEsxCzAJBgNVBAYT
+AlVTMQswCQYDVQQIDAJDQTEMMAoGA1UEBwwDU0pDMRAwDgYDVQQKDAdUcmlyZW1l
+MQ8wDQYDVQQDDAZ1YnVudHUwHhcNMTYwOTI3MjI0OTAwWhcNMjYwOTI1MjI0OTAw
+WjBLMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExDDAKBgNVBAcMA1NKQzEQMA4G
+A1UECgwHVHJpcmVtZTEPMA0GA1UEAwwGdWJ1bnR1MFkwEwYHKoZIzj0CAQYIKoZI
+zj0DAQcDQgAE4c2Fd7XeIB1Vfs51fWwREfLLDa55J+NBalV12CH7YEAnEXjl47aV
+cmNqcAtdMUpf2oz9nFVI81bgO+OSudr3CqNQME4wHQYDVR0OBBYEFOBftuI09mmu
+rXjqDyIta1gT8lqvMB8GA1UdIwQYMBaAFOBftuI09mmurXjqDyIta1gT8lqvMAwG
+A1UdEwQFMAMBAf8wCgYIKoZIzj0EAwIDSQAwRgIhAMylAHhbFA0KqhXIFiXNpEbH
+JKaELL6UXXdeQ5yup8q+AiEAh5laB9rbgTymjaANcZ2YzEZH4VFS3CKoSdVqgnwC
+dW4=
+-----END CERTIFICATE-----`
+
+	certPEM = `-----BEGIN CERTIFICATE-----
+MIIBhjCCASwCCQCPCdgp39gHJTAKBggqhkjOPQQDAjBLMQswCQYDVQQGEwJVUzEL
+MAkGA1UECAwCQ0ExDDAKBgNVBAcMA1NKQzEQMA4GA1UECgwHVHJpcmVtZTEPMA0G
+A1UEAwwGdWJ1bnR1MB4XDTE2MDkyNzIyNDkwMFoXDTI2MDkyNTIyNDkwMFowSzEL
+MAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMQwwCgYDVQQHDANTSkMxEDAOBgNVBAoM
+B1RyaXJlbWUxDzANBgNVBAMMBnVidW50dTBZMBMGByqGSM49AgEGCCqGSM49AwEH
+A0IABAHwC/gHz4/w58a1OrVJBMsxMgsZ35TlsYaLstW3c4Se78TG9b0N9fGW1v1r
+zDf6IyF6l2KxKSEqKI854+OsOuMwCgYIKoZIzj0EAwIDSAAwRQIgQwQn0jnK/XvD
+KxgQd/0pW5FOAaB41cMcw4/XVlphO1oCIQDlGie+WlOMjCzrV0Xz+XqIIi1pIgPT
+IG7Nv+YlTVp5qA==
+-----END CERTIFICATE-----`
+)
+
+func TestNewConfig(t *testing.T) {
+	Convey("When I create a new PKI configuration", t, func() {
+		key, cert, _, err := crypto.LoadAndVerifyECSecrets([]byte(keyPEM), []byte(certPEM), []byte(caPool))
+		So(err, ShouldBeNil)
+		Convey("When I use  valid keys, it should succeed ", func() {
+			p := NewConfig(cert.PublicKey.(*ecdsa.PublicKey), key, -1)
+			So(p, ShouldNotBeNil)
+			So(p.validity, ShouldEqual, defaultValidity*time.Second)
+			So(p.privateKey, ShouldEqual, key)
+			So(p.publicKey, ShouldEqual, cert.PublicKey.(*ecdsa.PublicKey))
+		})
+
+		Convey("When I create a verifier with a custom validity, it should succeed  ", func() {
+			p := NewConfig(cert.PublicKey.(*ecdsa.PublicKey), key, 10*time.Second)
+			So(p, ShouldNotBeNil)
+			So(p.validity, ShouldEqual, 10*time.Second)
+			So(p.privateKey, ShouldEqual, key)
+			So(p.publicKey, ShouldEqual, cert.PublicKey.(*ecdsa.PublicKey))
+		})
+	})
+}
+
+func TestCreateAndVerify(t *testing.T) {
+	Convey("Given a valid verifier", t, func() {
+		key, cert, _, err := crypto.LoadAndVerifyECSecrets([]byte(keyPEM), []byte(certPEM), []byte(caPool))
+		So(err, ShouldBeNil)
+		p := NewConfig(cert.PublicKey.(*ecdsa.PublicKey), key, -1)
+		So(p, ShouldNotBeNil)
+		Convey("When I create a token", func() {
+			token, err1 := p.CreateTokenFromCertificate(cert)
+			So(err1, ShouldBeNil)
+			rxtoken, err2 := p.Verify(token)
+			So(err2, ShouldBeNil)
+			So(*rxtoken.X, ShouldResemble, *cert.PublicKey.(*ecdsa.PublicKey).X)
+			So(*rxtoken.Y, ShouldResemble, *cert.PublicKey.(*ecdsa.PublicKey).Y)
+			So(rxtoken.Curve, ShouldResemble, cert.PublicKey.(*ecdsa.PublicKey).Curve)
+		})
+	})
+
+	Convey("Given a valid verifier", t, func() {
+		key, cert, _, err := crypto.LoadAndVerifyECSecrets([]byte(keyPEM), []byte(certPEM), []byte(caPool))
+		So(err, ShouldBeNil)
+		p := NewConfig(cert.PublicKey.(*ecdsa.PublicKey), key, -1)
+		So(p, ShouldNotBeNil)
+		Convey("When I a receive a bad token, I should get an error", func() {
+			token, err1 := p.CreateTokenFromCertificate(cert)
+			So(err1, ShouldBeNil)
+			token = token[:len(token)-10]
+			_, err2 := p.Verify(token)
+			So(err2, ShouldNotBeNil)
+		})
+	})
+}
+
+func TestCaching(t *testing.T) {
+	Convey("Given a valid verifier with a zero timer for the cache", t, func() {
+		key, cert, _, err := crypto.LoadAndVerifyECSecrets([]byte(keyPEM), []byte(certPEM), []byte(caPool))
+		So(err, ShouldBeNil)
+		p := NewConfig(cert.PublicKey.(*ecdsa.PublicKey), key, 1*time.Second)
+		So(p, ShouldNotBeNil)
+
+		Convey("When I receive a token", func() {
+			token, err1 := p.CreateTokenFromCertificate(cert)
+			So(err1, ShouldBeNil)
+			_, err2 := p.Verify(token)
+			So(err2, ShouldBeNil)
+
+			Convey("The cache should have the token ", func() {
+				_, err := p.keycache.Get(string(token))
+				So(err, ShouldBeNil)
+				_, err2 := p.Verify(token)
+				So(err2, ShouldBeNil)
+			})
+
+			Convey("The cache should not have the token after 2 seconds ", func() {
+				time.Sleep(2 * time.Second)
+				_, err := p.keycache.Get(string(token))
+				So(err, ShouldNotBeNil)
+			})
+		})
+	})
+}

--- a/enforcer/utils/rpcwrapper/types.go
+++ b/enforcer/utils/rpcwrapper/types.go
@@ -47,6 +47,7 @@ type InitRequestPayload struct {
 	CAPEM      []byte                `json:",omitempty"`
 	PublicPEM  []byte                `json:",omitempty"`
 	PrivatePEM []byte                `json:",omitempty"`
+	Token      []byte                `json:",omitempty"`
 }
 
 //InitSupervisorPayload for supervisor init request

--- a/enforcer/utils/tokens/compactpki.go
+++ b/enforcer/utils/tokens/compactpki.go
@@ -1,0 +1,112 @@
+package tokens
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"fmt"
+
+	"github.com/aporeto-inc/trireme/crypto"
+	"github.com/aporeto-inc/trireme/enforcer/utils/pkiverifier"
+)
+
+// CompactPKI holds all PKI information
+type CompactPKI struct {
+	PrivateKeyPEM []byte
+	PublicKeyPEM  []byte
+	AuthorityPEM  []byte
+	privateKey    *ecdsa.PrivateKey
+	publicKey     *x509.Certificate
+	certPool      *x509.CertPool
+	txKey         []byte
+	verifier      *pkiverifier.PKIConfiguration
+}
+
+// NewCompactPKI creates new secrets for PKI implementation based on compact encoding
+func NewCompactPKI(keyPEM, certPEM, caPEM, txKey []byte) (*CompactPKI, error) {
+
+	key, cert, caCertPool, err := crypto.LoadAndVerifyECSecrets(keyPEM, certPEM, caPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	caKey, err := crypto.LoadCertificate(caPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(txKey) == 0 {
+		return nil, fmt.Errorf("TransmitToken missing")
+	}
+
+	p := &CompactPKI{
+		PrivateKeyPEM: keyPEM,
+		PublicKeyPEM:  certPEM,
+		AuthorityPEM:  caPEM,
+		privateKey:    key,
+		publicKey:     cert,
+		certPool:      caCertPool,
+		txKey:         txKey,
+		verifier:      pkiverifier.NewConfig(caKey.PublicKey.(*ecdsa.PublicKey), nil, -1),
+	}
+
+	return p, nil
+}
+
+// Type implements the interface Secrets
+func (p *CompactPKI) Type() SecretsType {
+	return PKICompactType
+}
+
+// EncodingKey returns the private key
+func (p *CompactPKI) EncodingKey() interface{} {
+	return p.privateKey
+}
+
+// DecodingKey returns the public key
+func (p *CompactPKI) DecodingKey(server string, ackKey interface{}, prevKey interface{}) (interface{}, error) {
+
+	// If we have an inband certificate, return this one
+	if ackKey != nil {
+		return ackKey.(*ecdsa.PublicKey), nil
+	}
+
+	// Otherwise, return the prevCert
+	if prevKey != nil {
+		return prevKey, nil
+	}
+
+	return nil, fmt.Errorf("No valid certificate")
+}
+
+// VerifyPublicKey verifies if the inband public key is correct.
+func (p *CompactPKI) VerifyPublicKey(pkey []byte) (interface{}, error) {
+
+	return p.verifier.Verify(pkey)
+
+}
+
+// TransmittedKey returns the PEM of the public key in the case of PKI
+// if there is no certificate cache configured
+func (p *CompactPKI) TransmittedKey() []byte {
+	return p.txKey
+}
+
+// AckSize returns the default size of an ACK packet
+func (p *CompactPKI) AckSize() uint32 {
+	return uint32(375)
+}
+
+// AuthPEM returns the Certificate Authority PEM
+func (p *CompactPKI) AuthPEM() []byte {
+	return p.AuthorityPEM
+}
+
+// TransmittedPEM returns the PEM certificate that is transmitted
+func (p *CompactPKI) TransmittedPEM() []byte {
+	return p.PublicKeyPEM
+}
+
+// EncodingPEM returns the certificate PEM that is used for encoding
+func (p *CompactPKI) EncodingPEM() []byte {
+	return p.PrivateKeyPEM
+}

--- a/enforcer/utils/tokens/compactpki_test.go
+++ b/enforcer/utils/tokens/compactpki_test.go
@@ -132,7 +132,7 @@ func TestBasicInterfaceFunctions(t *testing.T) {
 		})
 
 		Convey("I should ge the righ ack size", func() {
-			So(p.AckSize(), ShouldEqual, 336)
+			So(p.AckSize(), ShouldEqual, 375)
 		})
 
 		Convey("When I verify the received public key, it should succeed", func() {
@@ -148,7 +148,7 @@ func TestBasicInterfaceFunctions(t *testing.T) {
 		})
 
 		Convey("When I try to get the decoding key with the ack", func() {
-			key, err := p.DecodingKey("server", txKey, nil)
+			key, err := p.DecodingKey("server", cert.PublicKey, nil)
 			So(err, ShouldBeNil)
 			So(key.(*ecdsa.PublicKey), ShouldResemble, cert.PublicKey.(*ecdsa.PublicKey))
 		})

--- a/enforcer/utils/tokens/compactpki_test.go
+++ b/enforcer/utils/tokens/compactpki_test.go
@@ -1,0 +1,161 @@
+package tokens
+
+import (
+	"crypto/ecdsa"
+	"testing"
+
+	"github.com/aporeto-inc/trireme/crypto"
+	"github.com/aporeto-inc/trireme/enforcer/utils/pkiverifier"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var (
+	caPEM = `-----BEGIN CERTIFICATE-----
+MIIB9jCCAZ2gAwIBAgIJAJTgLK9oj4fKMAoGCCqGSM49BAMDMFgxCzAJBgNVBAYT
+AlVTMQswCQYDVQQIDAJDQTERMA8GA1UEBwwIU2FuIEpvc2UxEDAOBgNVBAoMB0Fw
+b3JldG8xFzAVBgNVBAMMDmFwb211eC5wcml2YXRlMB4XDTE3MDQzMDE1NTgyNFoX
+DTI3MDQyODE1NTgyNFowWDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMREwDwYD
+VQQHDAhTYW4gSm9zZTEQMA4GA1UECgwHQXBvcmV0bzEXMBUGA1UEAwwOYXBvbXV4
+LnByaXZhdGUwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATVcrrOIlMO/ty7cgCI
+YTeUcYY9nPiLdbEcQI5rT9vxoQ6wIIeUeO61TvSKXIa5s1qgJNnVnerfPIgKxQ/y
+q9KGo1AwTjAdBgNVHQ4EFgQUcJHVuZ7plgh4yj+qRwDSKwDJBmMwHwYDVR0jBBgw
+FoAUcJHVuZ7plgh4yj+qRwDSKwDJBmMwDAYDVR0TBAUwAwEB/zAKBggqhkjOPQQD
+AwNHADBEAiBivt359l723AELpmTKnGtnUCtnHCLUGwX1jMaYaVp+uwIgGEfM6d50
+RS0FNXCgNPdSLl6wTSLdZnVG+SXLnNNvb5g=
+-----END CERTIFICATE-----`
+	caKeyPEM = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIJ/aEmqa3eFqVbs2ITHAsEJpSjeeZhQUk+20gwmXmQbIoAoGCCqGSM49
+AwEHoUQDQgAE1XK6ziJTDv7cu3IAiGE3lHGGPZz4i3WxHECOa0/b8aEOsCCHlHju
+tU70ilyGubNaoCTZ1Z3q3zyICsUP8qvShg==
+-----END EC PRIVATE KEY-----`
+	privateKeyPEM = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIJHanaD9zGLPe/XdkA7fj7ocRFK7x7yun3299Gv/eIFroAoGCCqGSM49
+AwEHoUQDQgAEKsTNnVOtYN1LbVQssEuRx+Y+Jj2tz5wV8H36OzhD2aEZzVfgUPgB
+9P8vQrXLSwrhwx0lUCegBVNyfnIjDFuhew==
+-----END EC PRIVATE KEY-----`
+	publicPEM = `-----BEGIN CERTIFICATE-----
+MIICLjCCAdSgAwIBAgIRAJHHS9iyyJ3zFt30H1bcfOowCgYIKoZIzj0EAwIwWDEL
+MAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMREwDwYDVQQHDAhTYW4gSm9zZTEQMA4G
+A1UECgwHQXBvcmV0bzEXMBUGA1UEAwwOYXBvbXV4LnByaXZhdGUwHhcNMTcwNDMw
+MjA1NTUzWhcNMTgwNDMwMjA1NTUzWjBYMQ8wDQYDVQQKEwZzeXN0ZW0xGjAYBgNV
+BAsTEWFwb3JldG8tZW5mb3JjZXJkMSkwJwYDVQQDDCA1OTA2NGY1OTcxMGJkMDQ4
+MjEzYjFiMzdAL2Fwb211eDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABCrEzZ1T
+rWDdS21ULLBLkcfmPiY9rc+cFfB9+js4Q9mhGc1X4FD4AfT/L0K1y0sK4cMdJVAn
+oAVTcn5yIwxboXujfzB9MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAM
+BgNVHRMBAf8EAjAAMB8GA1UdIwQYMBaAFHCR1bme6ZYIeMo/qkcA0isAyQZjMC0G
+A1UdEQQmMCSCEGFwb211eC1lbmZvcmNlcmSBEGFwb211eC1lbmZvcmNlcmQwCgYI
+KoZIzj0EAwIDSAAwRQIgLyFySAkpi0Tk3mKiExAxVHmB2ub6N3Nb9qXAwwlqCYcC
+IQC9S/1lG5UDOC4sgnK/atyU3AWoUHsyeV8UTS/uY8p/Ag==
+-----END CERTIFICATE-----`
+)
+
+func createTxtToken() []byte {
+	caKey, err := crypto.LoadEllipticCurveKey([]byte(caKeyPEM))
+	if err != nil {
+		panic("bad ca key ")
+	}
+	caCert, err := crypto.LoadCertificate([]byte(caPEM))
+	if err != nil {
+		panic("bad ca cert")
+	}
+
+	clientCert, err := crypto.LoadCertificate([]byte(publicPEM))
+	if err != nil {
+		panic("bad client cert ")
+	}
+
+	p := pkiverifier.NewConfig(caCert.PublicKey.(*ecdsa.PublicKey), caKey, -1)
+	token, err := p.CreateTokenFromCertificate(clientCert)
+	if err != nil {
+		panic("can't create token")
+	}
+	return token
+}
+
+func TestNewCompactPKI(t *testing.T) {
+	txKey := createTxtToken()
+	// txkey is a token that has the client public key signed by the CA
+	Convey("When I create a new compact PKI, it should succeed ", t, func() {
+
+		p, err := NewCompactPKI([]byte(privateKeyPEM), []byte(publicPEM), []byte(caPEM), txKey)
+		So(err, ShouldBeNil)
+		So(p, ShouldNotBeNil)
+		So(p.AuthorityPEM, ShouldResemble, []byte(caPEM))
+		So(p.PrivateKeyPEM, ShouldResemble, []byte(privateKeyPEM))
+		So(p.PublicKeyPEM, ShouldResemble, []byte(publicPEM))
+	})
+
+	Convey("When I create a new compact PKI with invalid certs, it should fail", t, func() {
+		p, err := NewCompactPKI([]byte(keyPEM)[:20], []byte(certPEM)[:30], []byte(caPool), txKey)
+		So(err, ShouldNotBeNil)
+		So(p, ShouldBeNil)
+	})
+
+	Convey("When I create a new compact PKI with invalid CA, it should fail", t, func() {
+		p, err := NewCompactPKI([]byte(keyPEM), []byte(certPEM), []byte(caPool)[:10], txKey)
+		So(err, ShouldNotBeNil)
+		So(p, ShouldBeNil)
+	})
+
+}
+
+func TestBasicInterfaceFunctions(t *testing.T) {
+	txKey := createTxtToken()
+	Convey("Given a valid CompactPKI ", t, func() {
+		p, err := NewCompactPKI([]byte(privateKeyPEM), []byte(publicPEM), []byte(caPEM), txKey)
+		So(err, ShouldBeNil)
+		So(p, ShouldNotBeNil)
+
+		key, cert, _, _ := crypto.LoadAndVerifyECSecrets([]byte(privateKeyPEM), []byte(publicPEM), []byte(caPEM))
+		Convey("I should get the right secrets type ", func() {
+			So(p.Type(), ShouldResemble, PKICompactType)
+		})
+
+		Convey("I should get the right encoding key", func() {
+			So(*(p.EncodingKey().(*ecdsa.PrivateKey)), ShouldResemble, *key)
+		})
+
+		Convey("I should get the right transmitter key", func() {
+			So(p.TransmittedKey(), ShouldResemble, txKey)
+		})
+
+		Convey("I should get the right CA Auth PEM file", func() {
+			So(p.AuthPEM(), ShouldResemble, []byte(caPEM))
+		})
+
+		Convey("I should get the right Certificate PEM", func() {
+			So(p.TransmittedPEM(), ShouldResemble, []byte(publicPEM))
+		})
+
+		Convey("I Should get the right Key PEM", func() {
+			So(p.EncodingPEM(), ShouldResemble, []byte(privateKeyPEM))
+		})
+
+		Convey("I should ge the righ ack size", func() {
+			So(p.AckSize(), ShouldEqual, 336)
+		})
+
+		Convey("When I verify the received public key, it should succeed", func() {
+			pk, err := p.VerifyPublicKey(txKey)
+			So(err, ShouldBeNil)
+			So(pk.(*ecdsa.PublicKey), ShouldResemble, cert.PublicKey.(*ecdsa.PublicKey))
+		})
+
+		Convey("When I try to get the decoding key when the ack key is nil", func() {
+			key, err := p.DecodingKey("server", nil, txKey)
+			So(err, ShouldBeNil)
+			So(key, ShouldResemble, txKey)
+		})
+
+		Convey("When I try to get the decoding key with the ack", func() {
+			key, err := p.DecodingKey("server", txKey, nil)
+			So(err, ShouldBeNil)
+			So(key.(*ecdsa.PublicKey), ShouldResemble, cert.PublicKey.(*ecdsa.PublicKey))
+		})
+
+		Convey("When I try to get the decoding key and both inputs are nil, I should get an error ", func() {
+			_, err := p.DecodingKey("server", nil, nil)
+			So(err, ShouldNotBeNil)
+		})
+	})
+}

--- a/enforcer/utils/tokens/jwt.go
+++ b/enforcer/utils/tokens/jwt.go
@@ -46,7 +46,8 @@ func NewJWT(validity time.Duration, issuer string, secrets Secrets) (*JWTConfig,
 	if secrets == nil {
 		return nil, fmt.Errorf("Secrets can not be nil")
 	}
-	if secrets.Type() == PKIType {
+
+	if secrets.Type() == PKIType || secrets.Type() == PKICompactType {
 		signMethod = jwt.SigningMethodES256
 	} else {
 		signMethod = jwt.SigningMethodHS256

--- a/enforcer/utils/tokens/tokens.go
+++ b/enforcer/utils/tokens/tokens.go
@@ -26,6 +26,8 @@ const (
 	PKIType SecretsType = iota
 	// PSKType  for symetric signing
 	PSKType
+	// PKICompactType is for asymetric signing using compact JWTs on the wire
+	PKICompactType
 )
 
 const (

--- a/utils/common/common.go
+++ b/utils/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"crypto/ecdsa"
 	"encoding/pem"
 	"io/ioutil"
 
@@ -8,7 +9,9 @@ import (
 
 	"github.com/aporeto-inc/trireme"
 	"github.com/aporeto-inc/trireme/configurator"
+	"github.com/aporeto-inc/trireme/crypto"
 	"github.com/aporeto-inc/trireme/enforcer"
+	"github.com/aporeto-inc/trireme/enforcer/utils/pkiverifier"
 	"github.com/aporeto-inc/trireme/monitor"
 	"github.com/aporeto-inc/trireme/monitor/dockermonitor"
 )
@@ -72,4 +75,69 @@ func HybridTriremeWithPSK(networks []string, extractor *dockermonitor.DockerMeta
 	pass := []byte("THIS IS A BAD PASSWORD")
 	// Use this if you want a pre-shared key implementation
 	return configurator.NewPSKHybridTriremeWithMonitor("Server1", policyEngine, ExternalProcessor, nil, false, pass, *extractor, killContainerError)
+}
+
+// HybridTriremeWithCompactPKI is a helper method to created a PKI implementation of Trireme
+func HybridTriremeWithCompactPKI(keyFile, certFile, caCertFile, caKeyFile string, networks []string, extractor *dockermonitor.DockerMetadataExtractor, remoteEnforcer bool, killContainerError bool) (trireme.Trireme, monitor.Monitor) {
+
+	// Load client cert
+	certPEM, err := ioutil.ReadFile(certFile)
+	if err != nil {
+		zap.L().Fatal(err.Error())
+	}
+
+	// Load key
+	keyPEM, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		zap.L().Fatal(err.Error())
+	}
+
+	block, _ := pem.Decode(keyPEM)
+	if block == nil {
+		zap.L().Fatal("Failed to read key PEM")
+	}
+
+	// Load CA cert
+	caCertPEM, err := ioutil.ReadFile(caCertFile)
+	if err != nil {
+		zap.L().Fatal(err.Error())
+	}
+
+	caKeyPEM, err := ioutil.ReadFile(caKeyFile)
+	if err != nil {
+		zap.L().Fatal(err.Error())
+	}
+
+	token, err := createTxtToken(caKeyPEM, caCertPEM, certPEM)
+	if err != nil {
+		zap.L().Fatal(err.Error())
+	}
+
+	policyEngine := NewCustomPolicyResolver(networks)
+
+	return configurator.NewCompactPKIWithDocker("Server1", policyEngine, ExternalProcessor, nil, false, keyPEM, certPEM, caCertPEM, token, *extractor, remoteEnforcer, killContainerError)
+
+}
+
+func createTxtToken(caKeyPEM, caPEM, certPEM []byte) ([]byte, error) {
+	caKey, err := crypto.LoadEllipticCurveKey(caKeyPEM)
+	if err != nil {
+		return nil, err
+	}
+	caCert, err := crypto.LoadCertificate(caPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	clientCert, err := crypto.LoadCertificate(certPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	p := pkiverifier.NewConfig(caCert.PublicKey.(*ecdsa.PublicKey), caKey, -1)
+	token, err := p.CreateTokenFromCertificate(clientCert)
+	if err != nil {
+		return nil, err
+	}
+	return token, nil
 }

--- a/utils/common/extractor.go
+++ b/utils/common/extractor.go
@@ -31,7 +31,7 @@ func SwarmExtractor(info *types.ContainerJSON) (*policy.PURuntime, error) {
 
 		serviceID := info.Config.Labels["com.docker.swarm.service.id"]
 
-		service, _, err := cli.ServiceInspectWithRaw(context.Background(), serviceID)
+		service, _, err := cli.ServiceInspectWithRaw(context.Background(), serviceID, types.ServiceInspectOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("Failed get swarm labels: %s", err)
 		}

--- a/utils/common/extractor.go
+++ b/utils/common/extractor.go
@@ -31,7 +31,7 @@ func SwarmExtractor(info *types.ContainerJSON) (*policy.PURuntime, error) {
 
 		serviceID := info.Config.Labels["com.docker.swarm.service.id"]
 
-		service, _, err := cli.ServiceInspectWithRaw(context.Background(), serviceID, types.ServiceInspectOptions{})
+		service, _, err := cli.ServiceInspectWithRaw(context.Background(), serviceID)
 		if err != nil {
 			return nil, fmt.Errorf("Failed get swarm labels: %s", err)
 		}

--- a/utils/common/handler.go
+++ b/utils/common/handler.go
@@ -80,21 +80,37 @@ func processDaemonArgs(arguments map[string]interface{}, processor enforcer.Pack
 		if arguments["--usePKI"].(bool) {
 			keyFile := arguments["--keyFile"].(string)
 			certFile := arguments["--certFile"].(string)
-			caCertFile := arguments["--caCert"].(string)
+			caCertFile := arguments["--caCertFile"].(string)
+			caCertKeyFile := arguments["--caKeyFile"].(string)
 			zap.L().Info("Setting up trireme with PKI",
 				zap.String("key", keyFile),
 				zap.String("cert", certFile),
 				zap.String("ca", caCertFile),
+				zap.String("ca", caCertKeyFile),
 			)
-			t, m = TriremeWithPKI(keyFile, certFile, caCertFile, targetNetworks, &customExtractor, remote, KillContainerOnError)
+			t, m = HybridTriremeWithCompactPKI(keyFile, certFile, caCertFile, caCertKeyFile, targetNetworks, &customExtractor, remote, KillContainerOnError)
 		} else {
 			zap.L().Info("Setting up trireme with PSK")
 			t, m = TriremeWithPSK(targetNetworks, &customExtractor, remote, KillContainerOnError)
 		}
 	} else { // Hybrid mode
-		t, m, rm = HybridTriremeWithPSK(targetNetworks, &customExtractor, KillContainerOnError)
-		if rm == nil {
-			zap.L().Fatal("Failed to create remote monitor for hybrid")
+		if arguments["--usePKI"].(bool) {
+			keyFile := arguments["--keyFile"].(string)
+			certFile := arguments["--certFile"].(string)
+			caCertFile := arguments["--caCertFile"].(string)
+			caCertKeyFile := arguments["--caKeyFile"].(string)
+			zap.L().Info("Setting up trireme with Compact PKI",
+				zap.String("key", keyFile),
+				zap.String("cert", certFile),
+				zap.String("ca", caCertFile),
+				zap.String("ca", caCertKeyFile),
+			)
+			t, m = HybridTriremeWithCompactPKI(keyFile, certFile, caCertFile, caCertKeyFile, targetNetworks, &customExtractor, true, KillContainerOnError)
+		} else {
+			t, m, rm = HybridTriremeWithPSK(targetNetworks, &customExtractor, KillContainerOnError)
+			if rm == nil {
+				zap.L().Fatal("Failed to create remote monitor for hybrid")
+			}
 		}
 	}
 


### PR DESCRIPTION
When servers use PKI for token exchange, the public key of the server was communicated over a certificate. However, certificates tend to be big and they eat a lot of resources. In the Trireme case we don't negotiate ciphers or require all the details of the certificates. With this PR we introduce a simpler mechanism where we just communicate over the wire the EC public keys signed by the 
CA without all the overheads. 