### PR TITLE
Using ipsets for target networks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
      packages:
        - libnetfilter-queue-dev
        - iptables
+       - ipset
 
 env:
   global:
@@ -23,7 +24,7 @@ before_install:
   - gometalinter.v1 --install
 
 install:
-  - mkdir -p $GOPATH/src/github.com/docker && cd $GOPATH/src/github.com/docker && git clone https://github.com/docker/docker -b 1.13.x docker && cd - 
+  - mkdir -p $GOPATH/src/github.com/docker && cd $GOPATH/src/github.com/docker && git clone https://github.com/docker/docker -b 1.13.x docker && cd -
   - go get -t -v ./...
 
 script:

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -257,7 +257,7 @@ func TestSetTimeOut(t *testing.T) {
 					So(d.(string), ShouldResemble, "test")
 
 					Convey("If I wait for another second, the data should be gone", func() {
-						<-time.After(1000 * time.Millisecond)
+						<-time.After(1200 * time.Millisecond)
 						val, err := c.Get("test")
 						So(err, ShouldNotBeNil)
 						So(val, ShouldBeNil)

--- a/supervisor/iptablesctrl/acls.go
+++ b/supervisor/iptablesctrl/acls.go
@@ -80,21 +80,21 @@ func (i *Instance) chainRules(appChain string, netChain string, ip string) [][]s
 }
 
 //trapRules provides the packet trap rules to add/delete
-func (i *Instance) trapRules(appChain string, netChain string, network string, appQueue string, netQueue string) [][]string {
+func (i *Instance) trapRules(appChain string, netChain string, appQueue string, netQueue string) [][]string {
 
 	rules := [][]string{}
 
 	if i.mode == constants.LocalContainer {
 		rules = append(rules, []string{
 			i.appPacketIPTableContext, appChain,
-			"-d", network,
+			"-m", "set", "--match-set", targetNetworkSet, "dst",
 			"-p", "tcp", "--tcp-flags", "FIN,SYN,RST,PSH,URG", "SYN",
 			"-j", "NFQUEUE", "--queue-balance", appQueue,
 		})
 
 		rules = append(rules, []string{
 			i.appAckPacketIPTableContext, appChain,
-			"-d", network,
+			"-m", "set", "--match-set", targetNetworkSet, "dst",
 			"-p", "tcp", "--tcp-flags", "SYN,ACK", "ACK",
 			"-m", "connbytes", "--connbytes", ":3", "--connbytes-dir", "original", "--connbytes-mode", "packets",
 			"-j", "NFQUEUE", "--queue-balance", appQueue,
@@ -103,7 +103,7 @@ func (i *Instance) trapRules(appChain string, netChain string, network string, a
 		// Capture the first ack packet
 		rules = append(rules, []string{
 			i.netPacketIPTableContext, netChain,
-			"-s", network,
+			"-m", "set", "--match-set", targetNetworkSet, "src",
 			"-p", "tcp",
 			"-m", "connbytes", "--connbytes", ":3", "--connbytes-dir", "original", "--connbytes-mode", "packets",
 			"-j", "NFQUEUE", "--queue-balance", netQueue,
@@ -112,14 +112,14 @@ func (i *Instance) trapRules(appChain string, netChain string, network string, a
 	} else {
 		rules = append(rules, []string{
 			i.appAckPacketIPTableContext, appChain,
-			"-d", network,
+			"-m", "set", "--match-set", targetNetworkSet, "dst",
 			"-p", "tcp", "--tcp-flags", "SYN,ACK", "SYN",
 			"-j", "NFQUEUE", "--queue-balance", appQueue,
 		})
 
 		rules = append(rules, []string{
 			i.appAckPacketIPTableContext, appChain,
-			"-d", network,
+			"-m", "set", "--match-set", targetNetworkSet, "dst",
 			"-p", "tcp", "--tcp-flags", "SYN,ACK", "ACK",
 			"-m", "connbytes", "--connbytes", ":3", "--connbytes-dir", "original", "--connbytes-mode", "packets",
 			"-j", "NFQUEUE", "--queue-balance", appQueue,
@@ -128,14 +128,14 @@ func (i *Instance) trapRules(appChain string, netChain string, network string, a
 		// Capture Syn Packets
 		rules = append(rules, []string{
 			i.netPacketIPTableContext, netChain,
-			"-s", network,
+			"-m", "set", "--match-set", targetNetworkSet, "src",
 			"-p", "tcp", "--tcp-flags", "SYN,ACK", "SYN",
 			"-j", "NFQUEUE", "--queue-balance", netQueue,
 		})
 
 		rules = append(rules, []string{
 			i.netPacketIPTableContext, netChain,
-			"-s", network,
+			"-m", "set", "--match-set", targetNetworkSet, "src",
 			"-p", "tcp", "--tcp-flags", "SYN,ACK,PSH", "ACK",
 			"-m", "connbytes", "--connbytes", ":3", "--connbytes-dir", "original", "--connbytes-mode", "packets",
 			"-j", "NFQUEUE", "--queue-balance", netQueue,
@@ -204,15 +204,8 @@ func (i *Instance) addChainRules(appChain string, netChain string, ip string, po
 // addPacketTrap adds the necessary iptables rules to capture control packets to user space
 func (i *Instance) addPacketTrap(appChain string, netChain string, ip string, networks []string) error {
 
-	for _, network := range networks {
+	return i.processRulesFromList(i.trapRules(appChain, netChain, i.applicationQueues, i.networkQueues), "Append")
 
-		err := i.processRulesFromList(i.trapRules(appChain, netChain, network, i.applicationQueues, i.networkQueues), "Append")
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // addAppACLs adds a set of rules to the external services that are initiated

--- a/supervisor/iptablesctrl/acls_test.go
+++ b/supervisor/iptablesctrl/acls_test.go
@@ -873,3 +873,51 @@ func TestClearCaptureSynAckPackets(t *testing.T) {
 		})
 	})
 }
+
+func TestUpdateTargetNetworks(t *testing.T) {
+	Convey("Given an iptables controller,", t, func() {
+		i, _ := NewInstance("0:1", "2:3", 0x1000, constants.LocalContainer)
+		iptables := provider.NewTestIptablesProvider()
+		i.ipt = iptables
+		ipsets := provider.NewTestIpsetProvider()
+		i.ipset = ipsets
+
+		Convey("When I create the target networks for the first time and ipset succeeds, it should succeed", func() {
+
+			ipsets.MockNewIpset(t, func(name string, hasht string, p *ipset.Params) (provider.Ipset, error) {
+				if name == targetNetworkSet {
+					testset := provider.NewTestIpset()
+					testset.MockAdd(t, func(entry string, timeout int) error {
+						if entry == "10.1.1.0/24" || entry == "20.1.1.0/24" || entry == "30.1.1.0/24" {
+							return nil
+						}
+						return fmt.Errorf("Error")
+					})
+
+					testset.MockDel(t, func(entry string) error {
+						if entry == "10.1.1.0/24" {
+							return nil
+						}
+						return fmt.Errorf("Error")
+					})
+
+					return testset, nil
+				}
+				return nil, fmt.Errorf("Wrong set")
+			})
+
+			err := i.createTargetSet([]string{"10.1.1.0/24", "20.1.1.0/24"})
+			So(err, ShouldBeNil)
+
+			Convey("When I update the target network and I delete an entry", func() {
+				err := i.updateTargetNetworks([]string{"10.1.1.0/24", "20.1.1.0/24"}, []string{"20.1.1.0/24"})
+				So(err, ShouldBeNil)
+			})
+
+			Convey("When I update the target network and I add an entry", func() {
+				err := i.updateTargetNetworks([]string{"10.1.1.0/24", "20.1.1.0/24"}, []string{"30.1.1.0/24"})
+				So(err, ShouldBeNil)
+			})
+		})
+	})
+}

--- a/supervisor/iptablesctrl/ipsets.go
+++ b/supervisor/iptablesctrl/ipsets.go
@@ -1,0 +1,57 @@
+package iptablesctrl
+
+import (
+	"fmt"
+
+	"github.com/bvandewalle/go-ipset/ipset"
+	"go.uber.org/zap"
+)
+
+// updateTargetNetworks updates the set of target networks. Tries to minimize
+// read/writes to the ipset structures
+func (i *Instance) updateTargetNetworks(old, new []string) error {
+
+	deleteMap := map[string]bool{}
+	for _, net := range old {
+		deleteMap[net] = true
+	}
+
+	for _, net := range new {
+		if _, ok := deleteMap[net]; ok {
+			deleteMap[net] = false
+			continue
+		}
+
+		if err := i.targetSet.Add(net, 0); err != nil {
+			return fmt.Errorf("Failed to update target set")
+		}
+	}
+
+	for net, delete := range deleteMap {
+		if delete {
+			if err := i.targetSet.Del(net); err != nil {
+				zap.L().Debug("Failed to remove network from set")
+			}
+		}
+	}
+	return nil
+}
+
+// createTargetSet creates a new target set
+func (i *Instance) createTargetSet(networks []string) error {
+
+	ips, err := i.ipset.NewIpset(targetNetworkSet, "hash:net", &ipset.Params{})
+	if err != nil {
+		return fmt.Errorf("Couldn't create IPSet for %s: %s", targetNetworkSet, err)
+	}
+
+	i.targetSet = ips
+
+	for _, net := range networks {
+		if err := i.targetSet.Add(net, 0); err != nil {
+			return fmt.Errorf("Error adding ip %s to target networks IPSet: %s", net, err)
+		}
+	}
+
+	return nil
+}

--- a/supervisor/iptablesctrl/iptables.go
+++ b/supervisor/iptablesctrl/iptables.go
@@ -326,5 +326,9 @@ func (i *Instance) Stop() error {
 		zap.L().Error("Failed to clean acls while stopping the supervisor", zap.Error(err))
 	}
 
+	if err := i.ipset.DestroyAll(); err != nil {
+		zap.L().Error("Failed to clean up ipsets", zap.Error(err))
+	}
+
 	return nil
 }

--- a/supervisor/iptablesctrl/iptables.go
+++ b/supervisor/iptablesctrl/iptables.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	chainPrefix    = "TRIREME-"
-	appChainPrefix = chainPrefix + "App-"
-	netChainPrefix = chainPrefix + "Net-"
+	chainPrefix      = "TRIREME-"
+	appChainPrefix   = chainPrefix + "App-"
+	netChainPrefix   = chainPrefix + "Net-"
+	targetNetworkSet = "TargetNetSet"
 )
 
 // Instance  is the structure holding all information about a implementation
@@ -25,6 +26,8 @@ type Instance struct {
 	applicationQueues          string
 	mark                       int
 	ipt                        provider.IptablesProvider
+	ipset                      provider.IpsetProvider
+	targetSet                  provider.Ipset
 	appPacketIPTableContext    string
 	appAckPacketIPTableContext string
 	appPacketIPTableSection    string
@@ -43,11 +46,17 @@ func NewInstance(networkQueues, applicationQueues string, mark int, mode constan
 		return nil, fmt.Errorf("Cannot initialize IPtables provider")
 	}
 
+	ips := provider.NewGoIPsetProvider()
+	if err != nil {
+		return nil, fmt.Errorf("Cannot initialize ipsets")
+	}
+
 	i := &Instance{
 		networkQueues:     networkQueues,
 		applicationQueues: applicationQueues,
 		mark:              mark,
 		ipt:               ipt,
+		ipset:             ips,
 		appPacketIPTableContext:    "raw",
 		appAckPacketIPTableContext: "mangle",
 		netPacketIPTableContext:    "mangle",
@@ -291,13 +300,16 @@ func (i *Instance) SetTargetNetworks(current, networks []string) error {
 
 	// Cleanup old ACLs
 	if len(current) > 0 {
-		if err := i.CleanCaptureSynAckPackets(current); err != nil {
-			return fmt.Errorf("Failed to clean synack networks")
-		}
+		return i.updateTargetNetworks(current, networks)
 	}
 
-	// Insert new ACLs
-	if err := i.captureTargetSynAckPackets(i.appPacketIPTableSection, i.netPacketIPTableSection, networks); err != nil {
+	// Create the target network set
+	if err := i.createTargetSet(networks); err != nil {
+		return err
+	}
+
+	// Insert the ACLS that point to the target networks
+	if err := i.captureTargetSynAckPackets(i.appPacketIPTableSection, i.netPacketIPTableSection); err != nil {
 		return fmt.Errorf("Failed to update synack networks")
 	}
 


### PR DESCRIPTION
The list of target networks can get rather big and this creates lots of overhead in the number
of ACLs that need to be managed. We can simplify this and reduce significantly the number of 
rules to effectively one by creating an ipset for the target networks. Updates are also simplified 
a lot.

This PR introduces ipsets in the target networks and solves it first for the capturing of synack packets.