### PR TITLE
Fix example constructors

### DIFF
--- a/cmd/remoteenforcer/remoteenforcer_linux.go
+++ b/cmd/remoteenforcer/remoteenforcer_linux.go
@@ -257,7 +257,10 @@ func (s *Server) InitSupervisor(req rpcwrapper.Request, resp *rpcwrapper.Respons
 
 		s.Supervisor.Start()
 
-		s.Service.Initialize(s.secrets, s.Enforcer.GetFilterQueue())
+		if s.Service != nil {
+			s.Service.Initialize(s.secrets, s.Enforcer.GetFilterQueue())
+		}
+
 	} else {
 		s.Supervisor.SetTargetNetworks(payload.TriremeNetworks)
 	}

--- a/enforcer/datapath.go
+++ b/enforcer/datapath.go
@@ -263,7 +263,9 @@ func (d *Datapath) Start() error {
 
 	zap.L().Debug("Start enforcer", zap.Int("mode", int(d.mode)))
 
-	d.service.Initialize(d.secrets, d.filterQueue)
+	if d.service != nil {
+		d.service.Initialize(d.secrets, d.filterQueue)
+	}
 
 	d.startApplicationInterceptor()
 	d.startNetworkInterceptor()


### PR DESCRIPTION
This PR fixes the example constructors in the library that were broken with the transition to stricter SynAck controls. 