### PR TITLE
Fix memory leak in nfqueue C code

### DIFF
--- a/enforcer/netfilter/netfilter.h
+++ b/enforcer/netfilter/netfilter.h
@@ -83,8 +83,11 @@ static inline void Run(struct nfq_handle *h, int fd)
 }
 
 // SetVerdict use the nfq API to set the verdict
-static inline int SetVerdict(struct nfq_q_handle *qh, int id, int verdict , int buffer_length , unsigned char *buffer ) {
-    return nfq_set_verdict(qh, id , verdict  , buffer_length, buffer );
+static inline int SetVerdict(struct nfq_q_handle *qh, int id, int verdict , int mark , int buffer_length , unsigned char *buffer ) {
+  int status;
+  status = nfq_set_verdict2(qh, id , verdict  , mark, buffer_length, buffer );
+  free(buffer);
+  return status;
 }
 
 #endif

--- a/enforcer/netfilter/netfilter_linux.go
+++ b/enforcer/netfilter/netfilter_linux.go
@@ -231,7 +231,7 @@ func SetVerdict(v *Verdict, mark int) int {
 
 	// Drop any bad packets immediately
 	if v.V == NfDrop {
-		verdict := C.SetVerdict(v.QueueHandle, C.int(v.ID), C.int(v.V), 0 , 0 , v.Xbuffer)
+		verdict := C.SetVerdict(v.QueueHandle, C.int(v.ID), C.int(v.V), 0, 0, v.Xbuffer)
 		return int(verdict)
 	}
 

--- a/enforcer/netfilter/netfilter_linux.go
+++ b/enforcer/netfilter/netfilter_linux.go
@@ -231,7 +231,7 @@ func SetVerdict(v *Verdict, mark int) int {
 
 	// Drop any bad packets immediately
 	if v.V == NfDrop {
-		verdict := C.nfq_set_verdict(v.QueueHandle, C.u_int32_t(v.ID), C.u_int32_t(v.V), 0, v.Xbuffer)
+		verdict := C.SetVerdict(v.QueueHandle, C.int(v.ID), C.int(v.V), 0 , 0 , v.Xbuffer)
 		return int(verdict)
 	}
 
@@ -260,7 +260,7 @@ func SetVerdict(v *Verdict, mark int) int {
 		length++
 	}
 
-	verdict := C.nfq_set_verdict2(v.QueueHandle, C.u_int32_t(v.ID), C.u_int32_t(v.V), C.u_int32_t(mark), C.u_int32_t(length), v.Xbuffer)
+	verdict := C.SetVerdict(v.QueueHandle, C.int(v.ID), C.int(v.V), C.int(mark), C.int(length), v.Xbuffer)
 
 	return int(verdict)
 }


### PR DESCRIPTION
This PR fixes a memory leak in the C code of the nfqueue wrapper. The allocated buffers for 
new packets were not released. 