### PR TITLE
Allow labels with the same key

### DIFF
--- a/cmd/remoteenforcer/remotecollector.go
+++ b/cmd/remoteenforcer/remotecollector.go
@@ -41,7 +41,6 @@ func (c *CollectorImpl) CollectFlowEvent(record *collector.FlowRecord) {
 
 	c.Flows[hash] = record
 
-	c.Flows[hash].Tags = c.Flows[hash].Tags
 }
 
 //CollectContainerEvent exported

--- a/cmd/remoteenforcer/remotecollector.go
+++ b/cmd/remoteenforcer/remotecollector.go
@@ -41,7 +41,7 @@ func (c *CollectorImpl) CollectFlowEvent(record *collector.FlowRecord) {
 
 	c.Flows[hash] = record
 
-	c.Flows[hash].Tags = c.Flows[hash].Tags.Clone()
+	c.Flows[hash].Tags = c.Flows[hash].Tags
 }
 
 //CollectContainerEvent exported

--- a/cmd/remoteenforcer/remotecollector_test.go
+++ b/cmd/remoteenforcer/remotecollector_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/aporeto-inc/trireme/collector"
-	"github.com/aporeto-inc/trireme/policy"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -33,7 +32,7 @@ func TestCollectFlowEvent(t *testing.T) {
 				DestinationIP:   "2.2.2.2",
 				DestinationPort: 80,
 				Count:           0,
-				Tags:            &policy.TagsMap{},
+				Tags:            []string{},
 			}
 			c.CollectFlowEvent(r)
 
@@ -52,7 +51,7 @@ func TestCollectFlowEvent(t *testing.T) {
 					DestinationIP:   "2.2.2.2",
 					DestinationPort: 80,
 					Count:           10,
-					Tags:            &policy.TagsMap{},
+					Tags:            []string{},
 				}
 				c.CollectFlowEvent(r)
 				Convey("The flow should be in the cache", func() {
@@ -71,7 +70,7 @@ func TestCollectFlowEvent(t *testing.T) {
 					DestinationIP:   "4.4.4.4",
 					DestinationPort: 80,
 					Count:           33,
-					Tags:            &policy.TagsMap{},
+					Tags:            []string{},
 				}
 				c.CollectFlowEvent(r)
 				Convey("The flow should be in the cache", func() {

--- a/cmd/systemdutil/systemdutil.go
+++ b/cmd/systemdutil/systemdutil.go
@@ -141,7 +141,7 @@ func createMetadata(servicename string, command string, ports string, metadata [
 		}
 	}
 
-  metadata = append(metadata, "port="+ports)
+	metadata = append(metadata, "port="+ports)
 	metadata = append(metadata, "execpath="+command)
 
 	name := command
@@ -149,7 +149,7 @@ func createMetadata(servicename string, command string, ports string, metadata [
 		name = servicename
 	}
 
-	return name, metadata , nil
+	return name, metadata, nil
 }
 
 // HandleCgroupStop handles the deletion of a cgroup

--- a/cmd/systemdutil/systemdutil.go
+++ b/cmd/systemdutil/systemdutil.go
@@ -123,9 +123,7 @@ func ExecuteCommand(arguments map[string]interface{}) error {
 }
 
 // createMetadata extracts the relevant metadata
-func createMetadata(servicename string, command string, ports string, metadata []string) (string, map[string]string, error) {
-
-	metadatamap := map[string]string{}
+func createMetadata(servicename string, command string, ports string, metadata []string) (string, []string, error) {
 
 	for _, element := range metadata {
 		keyvalue := strings.Split(element, "=")
@@ -141,20 +139,17 @@ func createMetadata(servicename string, command string, ports string, metadata [
 		if keyvalue[0] == "port" || keyvalue[0] == "execpath" {
 			return "", nil, fmt.Errorf("Metadata key cannot be port or execpath ")
 		}
-
-		metadatamap[keyvalue[0]] = keyvalue[1]
 	}
 
-	metadatamap["port"] = ports
-
-	metadatamap["execpath"] = command
+  metadata = append(metadata, "port="+ports)
+	metadata = append(metadata, "execpath="+command)
 
 	name := command
 	if servicename != "" {
 		name = servicename
 	}
 
-	return name, metadatamap, nil
+	return name, metadata , nil
 }
 
 // HandleCgroupStop handles the deletion of a cgroup

--- a/collector/default.go
+++ b/collector/default.go
@@ -1,21 +1,26 @@
 package collector
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
 
 // DefaultCollector implements a default collector infrastructure to syslog
 type DefaultCollector struct{}
 
 // CollectFlowEvent is part of the EventCollector interface.
-func (d *DefaultCollector) CollectFlowEvent(record *FlowRecord) {
+func (d *DefaultCollector) CollectFlowEvent(r *FlowRecord) {
 	return
 }
 
 // CollectContainerEvent is part of the EventCollector interface.
-func (d *DefaultCollector) CollectContainerEvent(record *ContainerRecord) {
+func (d *DefaultCollector) CollectContainerEvent(r *ContainerRecord) {
+	fmt.Printf("Container Event: %+v", *r)
 	return
 }
 
 // StatsFlowHash is a has function to hash flows
 func StatsFlowHash(r *FlowRecord) string {
+	fmt.Printf("Flow Event: %+v", *r)
 	return r.SourceID + ":" + r.DestinationID + ":" + strconv.Itoa(int(r.DestinationPort)) + ":" + r.Action + ":" + r.Mode
 }

--- a/collector/interfaces.go
+++ b/collector/interfaces.go
@@ -45,10 +45,10 @@ const (
 type EventCollector interface {
 
 	// CollectFlowEvent collect a  flow event.
-	CollectFlowEvent(record *FlowRecord)
+	CollectFlowEvent(r *FlowRecord)
 
 	// CollectContainerEvent collects a container events
-	CollectContainerEvent(record *ContainerRecord)
+	CollectContainerEvent(r *ContainerRecord)
 }
 
 // FlowRecord describes a flow record for statistis

--- a/collector/interfaces.go
+++ b/collector/interfaces.go
@@ -67,8 +67,9 @@ type FlowRecord struct {
 
 // ContainerRecord is a statistics record for a container
 type ContainerRecord struct {
-	ContextID string
-	IPAddress string
-	Tags      []string
-	Event     string
+	ContextID    string
+	ManagementID string
+	IPAddress    string
+	Tags         []string
+	Event        string
 }

--- a/collector/interfaces.go
+++ b/collector/interfaces.go
@@ -1,7 +1,5 @@
 package collector
 
-import "github.com/aporeto-inc/trireme/policy"
-
 const (
 	// FlowReject indicates that a flow was rejected
 	FlowReject = "reject"
@@ -62,7 +60,7 @@ type FlowRecord struct {
 	SourceIP        string
 	DestinationIP   string
 	DestinationPort uint16
-	Tags            *policy.TagsMap
+	Tags            []string
 	Action          string
 	Mode            string
 }
@@ -71,6 +69,6 @@ type FlowRecord struct {
 type ContainerRecord struct {
 	ContextID string
 	IPAddress string
-	Tags      *policy.TagsMap
+	Tags      []string
 	Event     string
 }

--- a/enforcer/constants.go
+++ b/enforcer/constants.go
@@ -7,8 +7,6 @@ const (
 	TCPAuthenticationOptionAckLen = 20
 	// PortNumberLabelString is the label to use for port numbers
 	PortNumberLabelString = "$sys:port"
-	// TransmitterLabel is the name of the label used to identify the Transmitter Context
-	TransmitterLabel = "AporetoContextID"
 	// DefaultNetwork to be used
 	DefaultNetwork = "0.0.0.0/0"
 )

--- a/enforcer/datapath.go
+++ b/enforcer/datapath.go
@@ -219,26 +219,29 @@ func (d *Datapath) Unenforce(contextID string) error {
 	defer puContext.(*PUContext).Unlock()
 
 	pu := puContext.(*PUContext)
-	if err := d.puFromIP.Remove(pu.IP); err != nil {
-		zap.L().Warn("Unable to remove cache entry during unenforcement",
-			zap.String("IP", pu.IP),
-			zap.Error(err),
-		)
-	}
 
-	if err := d.puFromIP.Remove(pu.Mark); err != nil {
-		zap.L().Warn("Unable to remove cache entry during unenforcement",
-			zap.String("Mark", pu.Mark),
-			zap.Error(err),
-		)
-	}
-
-	for _, port := range pu.Ports {
-		if err := d.puFromIP.Remove(port); err != nil {
+	if pu.PUType != constants.LinuxProcessPU {
+		if err := d.puFromIP.Remove(pu.IP); err != nil {
 			zap.L().Warn("Unable to remove cache entry during unenforcement",
-				zap.String("Port", port),
+				zap.String("IP", pu.IP),
 				zap.Error(err),
 			)
+		}
+	} else {
+		if err := d.puFromMark.Remove(pu.Mark); err != nil {
+			zap.L().Warn("Unable to remove cache entry during unenforcement",
+				zap.String("Mark", pu.Mark),
+				zap.Error(err),
+			)
+		}
+
+		for _, port := range pu.Ports {
+			if err := d.puFromPort.Remove(port); err != nil {
+				zap.L().Warn("Unable to remove cache entry during unenforcement",
+					zap.String("Port", port),
+					zap.Error(err),
+				)
+			}
 		}
 	}
 

--- a/enforcer/datapath_tcp.go
+++ b/enforcer/datapath_tcp.go
@@ -405,9 +405,8 @@ func (d *Datapath) processNetworkSynPacket(context *PUContext, conn *TCPConnecti
 		return nil, nil, fmt.Errorf("Syn packet dropped because of invalid token %v %+v", err, claims)
 	}
 
-	txLabel, ok := claims.T.Get(TransmitterLabel)
-	if err := tcpPacket.CheckTCPAuthenticationOption(TCPAuthenticationOptionBaseLen); !ok || err != nil {
-		d.reportRejectedFlow(tcpPacket, conn, txLabel, context.ManagementID, context, collector.InvalidFormat)
+	if err := tcpPacket.CheckTCPAuthenticationOption(TCPAuthenticationOptionBaseLen);  err != nil {
+		d.reportRejectedFlow(tcpPacket, conn, claims.ID, context.ManagementID, context, collector.InvalidFormat)
 		return nil, nil, fmt.Errorf("TCP Authentication Option not found %v", err)
 	}
 
@@ -417,7 +416,7 @@ func (d *Datapath) processNetworkSynPacket(context *PUContext, conn *TCPConnecti
 	tcpPacket.IncreaseTCPSeq((tcpDataLen - 1) + (d.ackSize))
 
 	if err := tcpPacket.TCPDataDetach(TCPAuthenticationOptionBaseLen); err != nil {
-		d.reportRejectedFlow(tcpPacket, conn, txLabel, context.ManagementID, context, collector.InvalidFormat)
+		d.reportRejectedFlow(tcpPacket, conn, claims.ID , context.ManagementID, context, collector.InvalidFormat)
 		return nil, nil, fmt.Errorf("Syn packet dropped because of invalid format %v", err)
 	}
 
@@ -425,12 +424,12 @@ func (d *Datapath) processNetworkSynPacket(context *PUContext, conn *TCPConnecti
 
 	// Add the port as a label with an @ prefix. These labels are invalid otherwise
 	// If all policies are restricted by port numbers this will allow port-specific policies
-	claims.T.Add(PortNumberLabelString, strconv.Itoa(int(tcpPacket.DestinationPort)))
+	claims.T = append(claims.T , PortNumberLabelString+"="+strconv.Itoa(int(tcpPacket.DestinationPort)) )
 
 	// Validate against reject rules first - We always process reject with higher priority
 	if index, _ := context.RejectRcvRules.Search(claims.T); index >= 0 {
 		// Reject the connection
-		d.reportRejectedFlow(tcpPacket, conn, txLabel, context.ManagementID, context, collector.PolicyDrop)
+		d.reportRejectedFlow(tcpPacket, conn, claims.ID, context.ManagementID, context, collector.PolicyDrop)
 		return nil, nil, fmt.Errorf("Connection rejected because of policy %+v", claims.T)
 	}
 
@@ -450,7 +449,7 @@ func (d *Datapath) processNetworkSynPacket(context *PUContext, conn *TCPConnecti
 		return action, claims, nil
 	}
 
-	d.reportRejectedFlow(tcpPacket, conn, txLabel, context.ManagementID, context, collector.PolicyDrop)
+	d.reportRejectedFlow(tcpPacket, conn, claims.ID , context.ManagementID, context, collector.PolicyDrop)
 	return nil, nil, fmt.Errorf("No matched tags - reject %+v", claims.T)
 }
 
@@ -601,6 +600,7 @@ func (d *Datapath) createSynPacketToken(context *PUContext, auth *AuthInfo) (tok
 	}
 
 	claims := &tokens.ConnectionClaims{
+		ID: context.ManagementID,
 		T: context.Identity,
 	}
 
@@ -619,6 +619,7 @@ func (d *Datapath) createSynPacketToken(context *PUContext, auth *AuthInfo) (tok
 func (d *Datapath) createSynAckPacketToken(context *PUContext, auth *AuthInfo) (token []byte, err error) {
 
 	claims := &tokens.ConnectionClaims{
+		ID: context.ManagementID,
 		T:   context.Identity,
 		RMT: auth.RemoteContext,
 	}
@@ -641,15 +642,9 @@ func (d *Datapath) parsePacketToken(auth *AuthInfo, data []byte) (*tokens.Connec
 		return nil, err
 	}
 
-	// We always a need a valid remote context ID
-	remoteContextID, ok := claims.T.Get(TransmitterLabel)
-	if !ok {
-		return nil, fmt.Errorf("No Transmitter Label ")
-	}
-
 	auth.RemotePublicKey = cert
 	auth.RemoteContext = nonce
-	auth.RemoteContextID = remoteContextID
+	auth.RemoteContextID = claims.ID
 
 	return claims, nil
 }

--- a/enforcer/datapath_tcp.go
+++ b/enforcer/datapath_tcp.go
@@ -405,7 +405,7 @@ func (d *Datapath) processNetworkSynPacket(context *PUContext, conn *TCPConnecti
 		return nil, nil, fmt.Errorf("Syn packet dropped because of invalid token %v %+v", err, claims)
 	}
 
-	if err := tcpPacket.CheckTCPAuthenticationOption(TCPAuthenticationOptionBaseLen);  err != nil {
+	if err := tcpPacket.CheckTCPAuthenticationOption(TCPAuthenticationOptionBaseLen); err != nil {
 		d.reportRejectedFlow(tcpPacket, conn, claims.ID, context.ManagementID, context, collector.InvalidFormat)
 		return nil, nil, fmt.Errorf("TCP Authentication Option not found %v", err)
 	}
@@ -416,7 +416,7 @@ func (d *Datapath) processNetworkSynPacket(context *PUContext, conn *TCPConnecti
 	tcpPacket.IncreaseTCPSeq((tcpDataLen - 1) + (d.ackSize))
 
 	if err := tcpPacket.TCPDataDetach(TCPAuthenticationOptionBaseLen); err != nil {
-		d.reportRejectedFlow(tcpPacket, conn, claims.ID , context.ManagementID, context, collector.InvalidFormat)
+		d.reportRejectedFlow(tcpPacket, conn, claims.ID, context.ManagementID, context, collector.InvalidFormat)
 		return nil, nil, fmt.Errorf("Syn packet dropped because of invalid format %v", err)
 	}
 
@@ -424,7 +424,7 @@ func (d *Datapath) processNetworkSynPacket(context *PUContext, conn *TCPConnecti
 
 	// Add the port as a label with an @ prefix. These labels are invalid otherwise
 	// If all policies are restricted by port numbers this will allow port-specific policies
-	claims.T = append(claims.T , PortNumberLabelString+"="+strconv.Itoa(int(tcpPacket.DestinationPort)) )
+	claims.T = append(claims.T, PortNumberLabelString+"="+strconv.Itoa(int(tcpPacket.DestinationPort)))
 
 	// Validate against reject rules first - We always process reject with higher priority
 	if index, _ := context.RejectRcvRules.Search(claims.T); index >= 0 {
@@ -449,7 +449,7 @@ func (d *Datapath) processNetworkSynPacket(context *PUContext, conn *TCPConnecti
 		return action, claims, nil
 	}
 
-	d.reportRejectedFlow(tcpPacket, conn, claims.ID , context.ManagementID, context, collector.PolicyDrop)
+	d.reportRejectedFlow(tcpPacket, conn, claims.ID, context.ManagementID, context, collector.PolicyDrop)
 	return nil, nil, fmt.Errorf("No matched tags - reject %+v", claims.T)
 }
 
@@ -601,7 +601,7 @@ func (d *Datapath) createSynPacketToken(context *PUContext, auth *AuthInfo) (tok
 
 	claims := &tokens.ConnectionClaims{
 		ID: context.ManagementID,
-		T: context.Identity,
+		T:  context.Identity,
 	}
 
 	if context.synToken, auth.LocalContext, err = d.tokenEngine.CreateAndSign(false, claims); err != nil {
@@ -619,7 +619,7 @@ func (d *Datapath) createSynPacketToken(context *PUContext, auth *AuthInfo) (tok
 func (d *Datapath) createSynAckPacketToken(context *PUContext, auth *AuthInfo) (token []byte, err error) {
 
 	claims := &tokens.ConnectionClaims{
-		ID: context.ManagementID,
+		ID:  context.ManagementID,
 		T:   context.Identity,
 		RMT: auth.RemoteContext,
 	}

--- a/enforcer/datapath_test.go
+++ b/enforcer/datapath_test.go
@@ -148,7 +148,7 @@ func setupProcessingUnitsInDatapathAndEnforce() (puInfo1, puInfo2 *policy.PUInfo
 
 		Clause: []policy.KeyValueOperator{
 			{
-				Key:      "TransmitterLabel",
+				Key:      "AporetoContextID",
 				Value:    []string{"value"},
 				Operator: policy.Equal,
 			},
@@ -172,6 +172,7 @@ func setupProcessingUnitsInDatapathAndEnforce() (puInfo1, puInfo2 *policy.PUInfo
 	ipl1 := policy.NewIPMap(map[string]string{policy.DefaultNamespace: puIP1})
 	puInfo1.Policy.SetIPAddresses(ipl1)
 	puInfo1.Policy.AddReceiverRules(&tagSelector)
+	puInfo1.Policy.AddIdentityTag("AporetoContextID=value")
 
 	// Create processing unit 2
 	puInfo2 = policy.NewPUInfo(puID2, constants.ContainerPU)
@@ -180,6 +181,7 @@ func setupProcessingUnitsInDatapathAndEnforce() (puInfo1, puInfo2 *policy.PUInfo
 	ipl2 := policy.NewIPMap(map[string]string{policy.DefaultNamespace: puIP2})
 	puInfo2.Policy.SetIPAddresses(ipl2)
 	puInfo2.Policy.AddReceiverRules(&tagSelector)
+	puInfo2.Policy.AddIdentityTag("AporetoContextID=value")
 
 	secret := secrets.NewPSKSecrets([]byte("Dummy Test Password"))
 

--- a/enforcer/datapath_test.go
+++ b/enforcer/datapath_test.go
@@ -148,7 +148,7 @@ func setupProcessingUnitsInDatapathAndEnforce() (puInfo1, puInfo2 *policy.PUInfo
 
 		Clause: []policy.KeyValueOperator{
 			{
-				Key:      TransmitterLabel,
+				Key:      "TransmitterLabel",
 				Value:    []string{"value"},
 				Operator: policy.Equal,
 			},
@@ -171,7 +171,6 @@ func setupProcessingUnitsInDatapathAndEnforce() (puInfo1, puInfo2 *policy.PUInfo
 	puInfo1.Runtime.SetIPAddresses(ip1)
 	ipl1 := policy.NewIPMap(map[string]string{policy.DefaultNamespace: puIP1})
 	puInfo1.Policy.SetIPAddresses(ipl1)
-	puInfo1.Policy.AddIdentityTag(TransmitterLabel, "value")
 	puInfo1.Policy.AddReceiverRules(&tagSelector)
 
 	// Create processing unit 2
@@ -180,7 +179,6 @@ func setupProcessingUnitsInDatapathAndEnforce() (puInfo1, puInfo2 *policy.PUInfo
 	puInfo2.Runtime.SetIPAddresses(ip2)
 	ipl2 := policy.NewIPMap(map[string]string{policy.DefaultNamespace: puIP2})
 	puInfo2.Policy.SetIPAddresses(ipl2)
-	puInfo2.Policy.AddIdentityTag(TransmitterLabel, "value")
 	puInfo2.Policy.AddReceiverRules(&tagSelector)
 
 	secret := secrets.NewPSKSecrets([]byte("Dummy Test Password"))
@@ -682,7 +680,6 @@ func TestPacketHandlingSrcPortCacheBehavior(t *testing.T) {
 						if tcpPacket.TCPFlags&packet.TCPSynAckMask == packet.TCPSynMask {
 							Convey("When I pass an application packet with SYN flag for packet "+string(i), func() {
 								Convey("Then I expect src port cache to be populated "+string(i), func() {
-									fmt.Println("SrcPortHash:" + tcpPacket.SourcePortHash(packet.PacketTypeApplication))
 									cs, es := enforcer.sourcePortConnectionCache.Get(tcpPacket.SourcePortHash(packet.PacketTypeApplication))
 									So(cs, ShouldNotBeNil)
 									So(es, ShouldBeNil)
@@ -697,7 +694,6 @@ func TestPacketHandlingSrcPortCacheBehavior(t *testing.T) {
 							} else {
 								Convey("When I pass any application packets with ACK flag for packet "+string(i), func() {
 									Convey("Then I expect src port cache to be NOT populated "+string(i), func() {
-										fmt.Println("SrcPortHash:" + tcpPacket.SourcePortHash(packet.PacketTypeApplication))
 										cs, es := enforcer.sourcePortConnectionCache.Get(tcpPacket.SourcePortHash(packet.PacketTypeApplication))
 										So(cs, ShouldBeNil)
 										So(es, ShouldNotBeNil)

--- a/enforcer/interfaces.go
+++ b/enforcer/interfaces.go
@@ -61,7 +61,7 @@ type PUContext struct {
 	ID             string
 	ManagementID   string
 	Identity       []string
-	Annotations    []string 
+	Annotations    []string
 	AcceptTxtRules *lookup.PolicyDB
 	RejectTxtRules *lookup.PolicyDB
 	AcceptRcvRules *lookup.PolicyDB

--- a/enforcer/interfaces.go
+++ b/enforcer/interfaces.go
@@ -60,8 +60,8 @@ type PacketProcessor interface {
 type PUContext struct {
 	ID             string
 	ManagementID   string
-	Identity       *policy.TagsMap
-	Annotations    *policy.TagsMap
+	Identity       []string
+	Annotations    []string 
 	AcceptTxtRules *lookup.PolicyDB
 	RejectTxtRules *lookup.PolicyDB
 	AcceptRcvRules *lookup.PolicyDB

--- a/enforcer/lookup/lookup.go
+++ b/enforcer/lookup/lookup.go
@@ -3,7 +3,8 @@ package lookup
 import (
 	"fmt"
 	"sort"
-  "strings"
+	"strings"
+
 	"go.uber.org/zap"
 
 	"github.com/aporeto-inc/trireme/policy"
@@ -139,12 +140,12 @@ func (m *PolicyDB) AddPolicy(selector policy.TagSelector) (policyID int) {
 
 }
 
-func (m *PolicyDB) KeyValueFromString( tag string) (key,value string ) {
+func (m *PolicyDB) keyValueFromString(tag string) (key, value string) {
 
 	parts := strings.SplitN(tag, "=", 2)
 
 	if len(parts) != 2 {
-		return "",""
+		return "", ""
 	}
 
 	return parts[0], parts[1]
@@ -158,8 +159,8 @@ func (m *PolicyDB) Search(tags []string) (int, interface{}) {
 	skip := make([]bool, m.numberOfPolicies+1)
 
 	// Disable all policies that fail the not key exists
-	for _, t := range tags  {
-		k, _  := m.KeyValueFromString(t)
+	for _, t := range tags {
+		k, _ := m.keyValueFromString(t)
 		for _, policy := range m.notStarTable[k] {
 			skip[policy.index] = true
 		}
@@ -168,7 +169,7 @@ func (m *PolicyDB) Search(tags []string) (int, interface{}) {
 	// Go through the list of tags
 	for _, t := range tags {
 
-		k,v := m.KeyValueFromString(t)
+		k, v := m.keyValueFromString(t)
 		// Search for matches of k=v
 		if index, action := searchInMapTabe(m.equalMapTable[k][v], count, skip); index >= 0 {
 			return index, action

--- a/enforcer/lookup/lookup.go
+++ b/enforcer/lookup/lookup.go
@@ -3,7 +3,7 @@ package lookup
 import (
 	"fmt"
 	"sort"
-
+  "strings"
 	"go.uber.org/zap"
 
 	"github.com/aporeto-inc/trireme/policy"
@@ -139,23 +139,36 @@ func (m *PolicyDB) AddPolicy(selector policy.TagSelector) (policyID int) {
 
 }
 
+func (m *PolicyDB) KeyValueFromString( tag string) (key,value string ) {
+
+	parts := strings.SplitN(tag, "=", 2)
+
+	if len(parts) != 2 {
+		return "",""
+	}
+
+	return parts[0], parts[1]
+}
+
 //Search searches for a set of tags in the database to find a policy match
-func (m *PolicyDB) Search(tags *policy.TagsMap) (int, interface{}) {
+func (m *PolicyDB) Search(tags []string) (int, interface{}) {
 
 	count := make([]int, m.numberOfPolicies+1)
 
 	skip := make([]bool, m.numberOfPolicies+1)
 
 	// Disable all policies that fail the not key exists
-	for k := range tags.Tags {
+	for _, t := range tags  {
+		k, _  := m.KeyValueFromString(t)
 		for _, policy := range m.notStarTable[k] {
 			skip[policy.index] = true
 		}
 	}
 
 	// Go through the list of tags
-	for k, v := range tags.Tags {
+	for _, t := range tags {
 
+		k,v := m.KeyValueFromString(t)
 		// Search for matches of k=v
 		if index, action := searchInMapTabe(m.equalMapTable[k][v], count, skip); index >= 0 {
 			return index, action

--- a/enforcer/lookup/lookup_test.go
+++ b/enforcer/lookup/lookup_test.go
@@ -219,117 +219,84 @@ func TestFuncSearch(t *testing.T) {
 			So(index9, ShouldEqual, 9)
 
 			Convey("Given that I search for a single matching that matches the equal rules, it should return the correct index,", func() {
-				tags := policy.NewTagsMap(map[string]string{
-					"app": "web",
-					"env": "demo",
-				})
+				tags := []string{"app=web", "env=demo"}
 				index, action := policyDB.Search(tags)
 				So(index, ShouldEqual, index1)
 				So(action.(policy.FlowAction), ShouldEqual, policy.Accept)
 			})
 
 			Convey("Given that I search for a single matching that matches the not equal rules, it should return the right index,", func() {
-				tags := policy.NewTagsMap(map[string]string{
-					"lang": "go",
-					"env":  "demo",
-				})
+				tags := []string{"lang=go", "env=demo"}
 				index, action := policyDB.Search(tags)
 				So(index, ShouldEqual, index2)
 				So(action.(policy.FlowAction), ShouldEqual, policy.Accept)
 			})
 
 			Convey("Given that I search for rules that match the KeyExists Policy, it should return the right index  ", func() {
-				tags := policy.NewTagsMap(map[string]string{
-					"dc":  "EAST",
-					"env": "demo",
-				})
+				tags := []string{"dc=EAST", "env=demo"}
 				index, action := policyDB.Search(tags)
 				So(index, ShouldEqual, index3)
 				So(action.(policy.FlowAction), ShouldEqual, policy.Accept)
 			})
 
 			Convey("Given that I search for a single matching that matches the Or rules, it should return the right index,", func() {
-				tags := policy.NewTagsMap(map[string]string{
-					"app": "web",
-					"env": "qa",
-				})
+				tags := []string{"app=web", "env=qa"}
 				index, action := policyDB.Search(tags)
 				So(index, ShouldEqual, index4)
 				So(action.(policy.FlowAction), ShouldEqual, policy.Accept)
 			})
 
 			Convey("Given that I search for a single matching that matches the NOT Or rlues, it should return the right index,", func() {
-				tags := policy.NewTagsMap(map[string]string{
-					"app": "web",
-					"env": "prod",
-				})
+				tags  := []string{"app=web", "env=prod"}
 				index, action := policyDB.Search(tags)
 				So(index, ShouldEqual, index5)
 				So(action.(policy.FlowAction), ShouldEqual, policy.Accept)
 			})
 
 			Convey("Given that I search for a single clause  that fails in the Not OR operator, it should fail ,", func() {
-				tags := policy.NewTagsMap(map[string]string{
-					"lang": "java",
-					"env":  "demo",
-					"app":  "db",
-				})
+				tags := []string{"lang=java", "env=demo", "app=db"}
 				index, action := policyDB.Search(tags)
 				So(index, ShouldEqual, -1)
 				So(action, ShouldEqual, nil)
 			})
 
 			Convey("Given that I search for rules that do not match, it should return an error ", func() {
-				tags := policy.NewTagsMap(map[string]string{
-					"tag": "none",
-					"env": "node",
-				})
+				tags := []string{"tag=none", "env=node"}
 				index, action := policyDB.Search(tags)
 				So(index, ShouldEqual, -1)
 				So(action, ShouldEqual, nil)
 			})
 
 			Convey("Given that I search for a single that succeeds in the Not Key  operator, it should succeed ,", func() {
-				tags := policy.NewTagsMap(map[string]string{
-					"app": "web",
-				})
+				tags := []string{"app=web"}
 				index, action := policyDB.Search(tags)
 				So(index, ShouldEqual, index6)
 				So(action.(policy.FlowAction), ShouldEqual, policy.Accept)
 			})
 
 			Convey("Given that I search for a value that matches a prefix", func() {
-				tags := policy.NewTagsMap(map[string]string{
-					"domain": "com.example.db",
-				})
+				tags := []string{"domain=com.example.db"}
 				index, action := policyDB.Search(tags)
 				So(index, ShouldEqual, index7)
 				So(action.(policy.FlowAction), ShouldEqual, policy.Accept)
 			})
 
 			Convey("Given that I search for a value that matches a complete value ", func() {
-				tags := policy.NewTagsMap(map[string]string{
-					"domain": "com.example.web",
-				})
+				tags := []string{"domain=com.example.web"}
 				index, action := policyDB.Search(tags)
 				So(index, ShouldEqual, index8)
 				So(action.(policy.FlowAction), ShouldEqual, policy.Accept)
 			})
 
 			Convey("Given that I search for a value that matches some of the prefix, it should return err  ", func() {
-				tags := policy.NewTagsMap(map[string]string{
-					"domain": "co",
-					"env":    "node",
-				})
+				tags := []string{"domain=co", "env=node"}
 				index, action := policyDB.Search(tags)
 				So(index, ShouldEqual, -1)
 				So(action, ShouldBeNil)
 			})
 
 			Convey("Given that I search for a value matches only the env not exists policy ", func() {
-				tags := policy.NewTagsMap(map[string]string{
-					"sometag": "nomatch",
-				})
+				tags := []string{"sometag=nomatch"}
 				index, action := policyDB.Search(tags)
 				So(index, ShouldEqual, index9)
 				So(action.(policy.FlowAction), ShouldEqual, policy.Accept)

--- a/enforcer/lookup/lookup_test.go
+++ b/enforcer/lookup/lookup_test.go
@@ -247,7 +247,7 @@ func TestFuncSearch(t *testing.T) {
 			})
 
 			Convey("Given that I search for a single matching that matches the NOT Or rlues, it should return the right index,", func() {
-				tags  := []string{"app=web", "env=prod"}
+				tags := []string{"app=web", "env=prod"}
 				index, action := policyDB.Search(tags)
 				So(index, ShouldEqual, index5)
 				So(action.(policy.FlowAction), ShouldEqual, policy.Accept)

--- a/enforcer/utils.go
+++ b/enforcer/utils.go
@@ -1,8 +1,6 @@
 package enforcer
 
 import (
-	"fmt"
-
 	"github.com/aporeto-inc/trireme/collector"
 	"github.com/aporeto-inc/trireme/enforcer/lookup"
 	"github.com/aporeto-inc/trireme/enforcer/utils/packet"
@@ -35,7 +33,6 @@ func (d *Datapath) reportRejectedFlow(p *packet.Packet, conn *TCPConnection, sou
 	if conn != nil {
 		conn.SetReported(AcceptReported)
 	}
-	fmt.Println("REJECTED", mode)
 	d.reportFlow(p, conn, sourceID, destID, context, collector.FlowReject, mode)
 }
 

--- a/enforcer/utils/rpcwrapper/types.go
+++ b/enforcer/utils/rpcwrapper/types.go
@@ -63,8 +63,8 @@ type EnforcePayload struct {
 	TriremeAction    policy.PUAction         `json:",omitempty"`
 	ApplicationACLs  *policy.IPRuleList      `json:",omitempty"`
 	NetworkACLs      *policy.IPRuleList      `json:",omitempty"`
-	Identity         *policy.TagsMap         `json:",omitempty"`
-	Annotations      *policy.TagsMap         `json:",omitempty"`
+	Identity         []string                `json:",omitempty"`
+	Annotations      []string                `json:",omitempty"`
 	PolicyIPs        *policy.IPMap           `json:",omitempty"`
 	ReceiverRules    *policy.TagSelectorList `json:",omitempty"`
 	TransmitterRules *policy.TagSelectorList `json:",omitempty"`
@@ -80,8 +80,8 @@ type SuperviseRequestPayload struct {
 	ApplicationACLs  *policy.IPRuleList      `json:",omitempty"`
 	NetworkACLs      *policy.IPRuleList      `json:",omitempty"`
 	PolicyIPs        *policy.IPMap           `json:",omitempty"`
-	Identity         *policy.TagsMap         `json:",omitempty"`
-	Annotations      *policy.TagsMap         `json:",omitempty"`
+	Identity         []string                `json:",omitempty"`
+	Annotations      []string                `json:",omitempty"`
 	ReceiverRules    *policy.TagSelectorList `json:",omitempty"`
 	TransmitterRules *policy.TagSelectorList `json:",omitempty"`
 	ExcludedNetworks []string                `json:",omitempty"`

--- a/enforcer/utils/secrets/compactpki.go
+++ b/enforcer/utils/secrets/compactpki.go
@@ -101,7 +101,7 @@ func (p *CompactPKI) TransmittedKey() []byte {
 
 // AckSize returns the default size of an ACK packet
 func (p *CompactPKI) AckSize() uint32 {
-	return uint32(332)
+	return uint32(322)
 }
 
 // AuthPEM returns the Certificate Authority PEM

--- a/enforcer/utils/secrets/compactpki.go
+++ b/enforcer/utils/secrets/compactpki.go
@@ -101,7 +101,7 @@ func (p *CompactPKI) TransmittedKey() []byte {
 
 // AckSize returns the default size of an ACK packet
 func (p *CompactPKI) AckSize() uint32 {
-	return uint32(322)
+	return uint32(332)
 }
 
 // AuthPEM returns the Certificate Authority PEM

--- a/enforcer/utils/secrets/compactpki_test.go
+++ b/enforcer/utils/secrets/compactpki_test.go
@@ -133,7 +133,7 @@ func TestBasicInterfaceFunctions(t *testing.T) {
 		})
 
 		Convey("I should ge the right ack size", func() {
-			So(p.AckSize(), ShouldEqual, 322)
+			So(p.AckSize(), ShouldEqual, 332)
 		})
 
 		Convey("I should get the right public key, ", func() {

--- a/enforcer/utils/secrets/psksecrets.go
+++ b/enforcer/utils/secrets/psksecrets.go
@@ -42,7 +42,7 @@ func (p *PSKSecrets) VerifyPublicKey(pkey []byte) (interface{}, error) {
 
 // AckSize returns the expected size of ack packets.
 func (p *PSKSecrets) AckSize() uint32 {
-	return uint32(279)
+	return uint32(289)
 }
 
 // AuthPEM returns the Certificate Authority PEM.

--- a/enforcer/utils/tokens/custom.go
+++ b/enforcer/utils/tokens/custom.go
@@ -5,11 +5,9 @@ import (
 	"crypto/ecdsa"
 	"crypto/hmac"
 	"crypto/x509"
-	"strings"
 	"time"
 
 	"github.com/aporeto-inc/trireme/crypto"
-	"github.com/aporeto-inc/trireme/policy"
 )
 
 // CustomTokenSignMethod describes the sign methods for the custome tokens
@@ -78,9 +76,8 @@ func (c *CustomTokenConfig) CreateAndSign(isAck bool, claims *ConnectionClaims) 
 
 	// If not an ACK packet copy the tags
 	if !isAck {
-		for k, v := range claims.T.Tags {
-			tag := []byte(k + "=" + v + " ")
-			buffer = append(buffer, tag...)
+		for _, v := range claims.T  {
+			buffer = append(buffer, []byte(v+" ")...)
 		}
 	}
 
@@ -120,18 +117,13 @@ func (c *CustomTokenConfig) Decode(isAck bool, data []byte, previousCert interfa
 	claims.RMT = data[rmtIndex : rmtIndex+sizeOfRandom]
 
 	if !isAck {
-		claims.T = policy.NewTagsMap(nil)
+		claims.T = []string{}
 		buffer := bytes.NewBuffer(data[minBufferLength:])
 		for {
 			tag, err := buffer.ReadBytes([]byte(" ")[0])
 
 			if err == nil {
-				values := strings.Split(string(tag[:len(tag)-1]), "=")
-				if len(values) != 2 {
-					continue
-				}
-
-				claims.T.Add(values[0], values[1])
+				claims.T = append(claims.T, string(tag[:len(tag)-1]) )
 				continue
 			}
 

--- a/enforcer/utils/tokens/custom.go
+++ b/enforcer/utils/tokens/custom.go
@@ -76,7 +76,7 @@ func (c *CustomTokenConfig) CreateAndSign(isAck bool, claims *ConnectionClaims) 
 
 	// If not an ACK packet copy the tags
 	if !isAck {
-		for _, v := range claims.T  {
+		for _, v := range claims.T {
 			buffer = append(buffer, []byte(v+" ")...)
 		}
 	}
@@ -123,7 +123,7 @@ func (c *CustomTokenConfig) Decode(isAck bool, data []byte, previousCert interfa
 			tag, err := buffer.ReadBytes([]byte(" ")[0])
 
 			if err == nil {
-				claims.T = append(claims.T, string(tag[:len(tag)-1]) )
+				claims.T = append(claims.T, string(tag[:len(tag)-1]))
 				continue
 			}
 

--- a/enforcer/utils/tokens/jwt.go
+++ b/enforcer/utils/tokens/jwt.go
@@ -84,7 +84,7 @@ func (c *JWTConfig) CreateAndSign(isAck bool, claims *ConnectionClaims) (token [
 		claims,
 		jwt.StandardClaims{
 			ExpiresAt: time.Now().Add(c.ValidityPeriod).Unix(),
-			Issuer:    c.Issuer,
+			Issuer: c.Issuer,
 		},
 	}
 

--- a/enforcer/utils/tokens/jwt.go
+++ b/enforcer/utils/tokens/jwt.go
@@ -84,7 +84,7 @@ func (c *JWTConfig) CreateAndSign(isAck bool, claims *ConnectionClaims) (token [
 		claims,
 		jwt.StandardClaims{
 			ExpiresAt: time.Now().Add(c.ValidityPeriod).Unix(),
-			Issuer: c.Issuer,
+			Issuer:    c.Issuer,
 		},
 	}
 

--- a/enforcer/utils/tokens/jwt_test.go
+++ b/enforcer/utils/tokens/jwt_test.go
@@ -179,7 +179,7 @@ func TestCreateAndVerifyPKI(t *testing.T) {
 			So(err2, ShouldBeNil)
 			So(err1, ShouldBeNil)
 			So(recoveredClaims, ShouldNotBeNil)
-			So(len(recoveredClaims.T), ShouldEqual, 2  )
+			So(len(recoveredClaims.T), ShouldEqual, 2)
 			So(recoveredClaims.T, ShouldContain, "label1=value1")
 			So(recoveredClaims.T, ShouldContain, "label2=value2")
 			So(string(recoveredClaims.RMT), ShouldEqual, rmt)

--- a/enforcer/utils/tokens/jwt_test.go
+++ b/enforcer/utils/tokens/jwt_test.go
@@ -7,16 +7,12 @@ import (
 
 	"github.com/aporeto-inc/trireme/crypto"
 	"github.com/aporeto-inc/trireme/enforcer/utils/secrets"
-	"github.com/aporeto-inc/trireme/policy"
 	jwt "github.com/dgrijalva/jwt-go"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 var (
-	tags = policy.NewTagsMap(map[string]string{
-		"label1": "value1",
-		"label2": "value2",
-	})
+	tags = []string{"label1=value1", "label2=value2"}
 
 	rmt           = "1234567890123456"
 	lcl           = "098765432109876"
@@ -143,8 +139,8 @@ func TestCreateAndVerifyPSK(t *testing.T) {
 			So(err1, ShouldBeNil)
 			So(err2, ShouldBeNil)
 			So(recoveredClaims, ShouldNotBeNil)
-			So(recoveredClaims.T.Tags["label1"], ShouldEqual, defaultClaims.T.Tags["label1"])
-			So(recoveredClaims.T.Tags["label2"], ShouldEqual, defaultClaims.T.Tags["label2"])
+			So(recoveredClaims.T, ShouldContain, "label1=value1")
+			So(recoveredClaims.T, ShouldContain, "label2=value2")
 			So(string(recoveredClaims.RMT), ShouldEqual, rmt)
 			So(recoveredNonce, ShouldResemble, nonce)
 		})
@@ -183,8 +179,9 @@ func TestCreateAndVerifyPKI(t *testing.T) {
 			So(err2, ShouldBeNil)
 			So(err1, ShouldBeNil)
 			So(recoveredClaims, ShouldNotBeNil)
-			So(recoveredClaims.T.Tags["label1"], ShouldEqual, defaultClaims.T.Tags["label1"])
-			So(recoveredClaims.T.Tags["label2"], ShouldEqual, defaultClaims.T.Tags["label2"])
+			So(len(recoveredClaims.T), ShouldEqual, 2  )
+			So(recoveredClaims.T, ShouldContain, "label1=value1")
+			So(recoveredClaims.T, ShouldContain, "label2=value2")
 			So(string(recoveredClaims.RMT), ShouldEqual, rmt)
 			So(string(recoveredClaims.LCL), ShouldEqual, "")
 			So(nonce, ShouldResemble, recoveredNonce)
@@ -203,10 +200,10 @@ func TestCreateAndVerifyPKI(t *testing.T) {
 			So(err4, ShouldBeNil)
 			So(recoveredClaims1, ShouldNotBeNil)
 			So(recoveredClaims2, ShouldNotBeNil)
-			So(recoveredClaims1.T.Tags["label1"], ShouldEqual, defaultClaims.T.Tags["label1"])
-			So(recoveredClaims1.T.Tags["label2"], ShouldEqual, defaultClaims.T.Tags["label2"])
-			So(recoveredClaims2.T.Tags["label1"], ShouldEqual, defaultClaims.T.Tags["label1"])
-			So(recoveredClaims2.T.Tags["label2"], ShouldEqual, defaultClaims.T.Tags["label2"])
+			So(recoveredClaims1.T, ShouldContain, "label1=value1")
+			So(recoveredClaims1.T, ShouldContain, "label2=value2")
+			So(recoveredClaims2.T, ShouldContain, "label1=value1")
+			So(recoveredClaims2.T, ShouldContain, "label2=value2")
 			So(string(recoveredClaims1.RMT), ShouldEqual, rmt)
 			So(string(recoveredClaims1.LCL), ShouldEqual, "")
 			So(string(recoveredClaims2.RMT), ShouldEqual, rmt)

--- a/enforcer/utils/tokens/tokens.go
+++ b/enforcer/utils/tokens/tokens.go
@@ -1,10 +1,11 @@
 package tokens
 
-import "github.com/aporeto-inc/trireme/policy"
-
 // ConnectionClaims captures all the claim information
 type ConnectionClaims struct {
-	T *policy.TagsMap
+	// ID is the ID of the transmitter
+	ID string 
+  // T is the set of tags associated with the claims
+	T []string
 	// RMT is the nonce of the remote that has to be signed in the JWT
 	RMT []byte
 	// LCL is the nonce of the local node that has to be signed

--- a/enforcer/utils/tokens/tokens.go
+++ b/enforcer/utils/tokens/tokens.go
@@ -3,8 +3,8 @@ package tokens
 // ConnectionClaims captures all the claim information
 type ConnectionClaims struct {
 	// ID is the ID of the transmitter
-	ID string 
-  // T is the set of tags associated with the claims
+	ID string
+	// T is the set of tags associated with the claims
 	T []string
 	// RMT is the nonce of the remote that has to be signed in the JWT
 	RMT []byte

--- a/monitor/dockermonitor/docker.go
+++ b/monitor/dockermonitor/docker.go
@@ -101,7 +101,7 @@ func initDockerClient(socketType string, socketAddress string) (*dockerClient.Cl
 func defaultDockerMetadataExtractor(info *types.ContainerJSON) (*policy.PURuntime, error) {
 
 	tags := []string{
-		"@sys:image=" + info.Config.Image ,
+		"@sys:image=" + info.Config.Image,
 		"@sys:name=" + info.Name,
 	}
 
@@ -452,10 +452,11 @@ func (d *dockerMonitor) handleStartEvent(event *events.Message) error {
 			}
 
 			d.collector.CollectContainerEvent(&collector.ContainerRecord{
-				ContextID: contextID,
-				IPAddress: "N/A",
-				Tags:      nil,
-				Event:     collector.ContainerFailed,
+				ContextID:    contextID,
+				ManagementID: "N/A",
+				IPAddress:    "N/A",
+				Tags:         nil,
+				Event:        collector.ContainerFailed,
 			})
 			return fmt.Errorf("Cannot read container information. Killing container. ")
 		}

--- a/monitor/dockermonitor/docker.go
+++ b/monitor/dockermonitor/docker.go
@@ -100,13 +100,13 @@ func initDockerClient(socketType string, socketAddress string) (*dockerClient.Cl
 
 func defaultDockerMetadataExtractor(info *types.ContainerJSON) (*policy.PURuntime, error) {
 
-	tags := policy.NewTagsMap(map[string]string{
-		"@sys:image": info.Config.Image,
-		"@sys:name":  info.Name,
-	})
+	tags := []string{
+		"@sys:image=" + info.Config.Image ,
+		"@sys:name=" + info.Name,
+	}
 
 	for k, v := range info.Config.Labels {
-		tags.Add("@usr:"+k, v)
+		tags = append(tags, "@usr:"+k+"="+v)
 	}
 
 	ipa := policy.NewIPMap(map[string]string{

--- a/monitor/linuxmonitor/cgnetcls/cgnetcls.go
+++ b/monitor/linuxmonitor/cgnetcls/cgnetcls.go
@@ -27,7 +27,7 @@ const (
 	// CgroupMarkTag is the tag for the cgroup mark
 	CgroupMarkTag = "@cgroup_mark"
 	// PortTag is the tag for a port
-	PortTag = "@usr:port"
+	PortTag = "port"
 
 	markFile             = "/net_cls.classid"
 	procs                = "/cgroup.procs"

--- a/monitor/linuxmonitor/linuxMonitor.go
+++ b/monitor/linuxmonitor/linuxMonitor.go
@@ -40,7 +40,7 @@ func SystemdRPCMetadataExtractor(event *rpcmonitor.EventInfo) (*policy.PURuntime
 
 	runtimeTags := make([]string, len(event.Tags))
 
-	for _, t  := range event.Tags {
+	for _, t := range event.Tags {
 		runtimeTags = append(runtimeTags, "@usr:"+t)
 		if strings.HasPrefix(t, cgnetcls.PortTag) {
 			options.Tags[cgnetcls.PortTag] = t[len(cgnetcls.PortTag)+1:]
@@ -50,18 +50,18 @@ func SystemdRPCMetadataExtractor(event *rpcmonitor.EventInfo) (*policy.PURuntime
 	userdata := processInfo(event.PID)
 
 	for _, u := range userdata {
-		runtimeTags = append(runtimeTags, "@sys:"+u )
+		runtimeTags = append(runtimeTags, "@sys:"+u)
 	}
 
-  runtimeTags = append(runtimeTags, "@sys:hostname=" + findFQFN())
+	runtimeTags = append(runtimeTags, "@sys:hostname="+findFQFN())
 
 	if fileMd5, err := ComputeMd5(event.Name); err == nil {
-		runtimeTags = append(runtimeTags, "@sys:filechecksum=" + hex.EncodeToString(fileMd5))
+		runtimeTags = append(runtimeTags, "@sys:filechecksum="+hex.EncodeToString(fileMd5))
 	}
 
 	depends := libs(event.Name)
 	for _, lib := range depends {
-		runtimeTags  = append(runtimeTags, "@sys:lib=" + lib )
+		runtimeTags = append(runtimeTags, "@sys:lib="+lib)
 	}
 
 	options.Tags[cgnetcls.CgroupMarkTag] = strconv.FormatUint(cgnetcls.MarkVal(), 10)

--- a/monitor/linuxmonitor/linuxMonitor.go
+++ b/monitor/linuxmonitor/linuxMonitor.go
@@ -41,6 +41,7 @@ func SystemdRPCMetadataExtractor(event *rpcmonitor.EventInfo) (*policy.PURuntime
 	runtimeTags := []string{}
 
 	for _, t := range event.Tags {
+		fmt.Println("TAG found", t)
 		runtimeTags = append(runtimeTags, "@usr:"+t)
 		if strings.HasPrefix(t, cgnetcls.PortTag) {
 			options.Tags[cgnetcls.PortTag] = t[len(cgnetcls.PortTag)+1:]

--- a/monitor/linuxmonitor/linuxMonitor.go
+++ b/monitor/linuxmonitor/linuxMonitor.go
@@ -41,7 +41,6 @@ func SystemdRPCMetadataExtractor(event *rpcmonitor.EventInfo) (*policy.PURuntime
 	runtimeTags := []string{}
 
 	for _, t := range event.Tags {
-		fmt.Println("TAG found", t)
 		runtimeTags = append(runtimeTags, "@usr:"+t)
 		if strings.HasPrefix(t, cgnetcls.PortTag) {
 			options.Tags[cgnetcls.PortTag] = t[len(cgnetcls.PortTag)+1:]

--- a/monitor/linuxmonitor/linuxmonitor_test.go
+++ b/monitor/linuxmonitor/linuxmonitor_test.go
@@ -99,9 +99,7 @@ func TestSystemdRPCMetadataExtractor(t *testing.T) {
 				Name: "./testdata/curl",
 				PID:  "1234",
 				PUID: "/1234",
-				Tags: map[string]string{
-					"app": "web",
-				},
+				Tags: []string{"app=web"},
 			}
 
 			pu, err := SystemdRPCMetadataExtractor(event)

--- a/monitor/linuxmonitor/processor.go
+++ b/monitor/linuxmonitor/processor.go
@@ -45,12 +45,12 @@ func (s *LinuxProcessor) Create(eventInfo *rpcmonitor.EventInfo) error {
 		return fmt.Errorf("Couldn't generate a contextID: %s", err)
 	}
 
-
 	s.collector.CollectContainerEvent(&collector.ContainerRecord{
-		ContextID: contextID,
-		IPAddress: "127.0.0.1",
-		Tags:      eventInfo.Tags,
-		Event:     collector.ContainerCreate,
+		ContextID:    contextID,
+		ManagementID: "N/A",
+		IPAddress:    "127.0.0.1",
+		Tags:         eventInfo.Tags,
+		Event:        collector.ContainerCreate,
 	})
 
 	// Send the event upstream
@@ -74,8 +74,6 @@ func (s *LinuxProcessor) Start(eventInfo *rpcmonitor.EventInfo) error {
 	if err = s.puHandler.SetPURuntime(contextID, runtimeInfo); err != nil {
 		return err
 	}
-
-	defaultIP, _ := runtimeInfo.DefaultIPAddress()
 
 	// Send the event upstream
 	errChan := s.puHandler.HandlePUEvent(contextID, monitor.EventStart)
@@ -116,13 +114,6 @@ func (s *LinuxProcessor) Start(eventInfo *rpcmonitor.EventInfo) error {
 			return err
 
 		}
-
-		s.collector.CollectContainerEvent(&collector.ContainerRecord{
-			ContextID: contextID,
-			IPAddress: defaultIP,
-			Tags:      runtimeInfo.Tags(),
-			Event:     collector.ContainerStart,
-		})
 	}
 
 	// Store the state in the context store for future access

--- a/monitor/linuxmonitor/processor.go
+++ b/monitor/linuxmonitor/processor.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aporeto-inc/trireme/monitor/contextstore"
 	"github.com/aporeto-inc/trireme/monitor/linuxmonitor/cgnetcls"
 	"github.com/aporeto-inc/trireme/monitor/rpcmonitor"
-	"github.com/aporeto-inc/trireme/policy"
 )
 
 // LinuxProcessor captures all the monitor processor information
@@ -46,12 +45,11 @@ func (s *LinuxProcessor) Create(eventInfo *rpcmonitor.EventInfo) error {
 		return fmt.Errorf("Couldn't generate a contextID: %s", err)
 	}
 
-	tagsMap := policy.NewTagsMap(eventInfo.Tags)
 
 	s.collector.CollectContainerEvent(&collector.ContainerRecord{
 		ContextID: contextID,
 		IPAddress: "127.0.0.1",
-		Tags:      tagsMap,
+		Tags:      eventInfo.Tags,
 		Event:     collector.ContainerCreate,
 	})
 

--- a/monitor/rpcmonitor/rpc.go
+++ b/monitor/rpcmonitor/rpc.go
@@ -275,7 +275,7 @@ func DefaultRPCMetadataExtractor(event *EventInfo) (*policy.PURuntime, error) {
 		return nil, fmt.Errorf("EventInfo PUID is empty")
 	}
 
-	runtimeTags := policy.NewTagsMap(event.Tags)
+	runtimeTags := event.Tags
 	runtimeIps := policy.NewIPMap(event.IPs)
 	runtimePID, err := strconv.Atoi(event.PID)
 	if err != nil {

--- a/monitor/rpcmonitor/rpctypes.go
+++ b/monitor/rpcmonitor/rpctypes.go
@@ -28,7 +28,7 @@ type EventInfo struct {
 	Name string
 
 	// Tags represents the set of MetadataTags associated with this PUID.
-	Tags map[string]string
+	Tags []string
 
 	// The PID is the PID on the system where this Processing Unit is running.
 	PID string

--- a/policy/interfaces.go
+++ b/policy/interfaces.go
@@ -20,11 +20,8 @@ type RuntimeReader interface {
 	// Name returns the process name of the Runtime.
 	Name() string
 
-	// Tag returns  the value of the given tag.
-	Tag(string) (string, bool)
-
 	// Tags returns a copy of the list of the tags.
-	Tags() *TagsMap
+	Tags() []string 
 
 	// Options returns a copy of the list of options.
 	Options() *TagsMap

--- a/policy/interfaces.go
+++ b/policy/interfaces.go
@@ -21,7 +21,7 @@ type RuntimeReader interface {
 	Name() string
 
 	// Tags returns a copy of the list of the tags.
-	Tags() []string 
+	Tags() []string
 
 	// Options returns a copy of the list of options.
 	Options() *TagsMap
@@ -54,10 +54,10 @@ type InfoInteractor interface {
 	TransmitterRules() *TagSelectorList
 
 	// Identity  returns a copy of the identity
-	Indentity() *TagsMap
+	Indentity() []string
 
 	// Annotations returns a copy of the Annotations
-	Annotations() *TagsMap
+	Annotations() []string
 
 	// DefaultIPAddress returns the default IP address for the processing unit
 	DefaultIPAddress() (string, bool)

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -171,7 +171,7 @@ func (p *PUPolicy) Identity() []string {
 	p.Lock()
 	defer p.Unlock()
 
-	return p.identity
+	return append([]string(nil), p.identity...)
 }
 
 // Annotations returns a copy of the annotations
@@ -179,7 +179,7 @@ func (p *PUPolicy) Annotations() []string {
 	p.Lock()
 	defer p.Unlock()
 
-	return p.annotations
+	return append([]string(nil), p.annotations...)
 }
 
 // AddIdentityTag adds a policy tag
@@ -187,7 +187,7 @@ func (p *PUPolicy) AddIdentityTag(tag string) {
 	p.Lock()
 	defer p.Unlock()
 
-	p.identity = append(p.identity, tag )
+	p.identity = append(p.identity, tag)
 }
 
 // IPAddresses returns all the IP addresses for the processing unit

--- a/policy/runtime.go
+++ b/policy/runtime.go
@@ -19,8 +19,8 @@ type PURuntime struct {
 	name string
 	// IPAddress is the IP Address of the container
 	ips *IPMap
-	// Tags is a map of the metadata of the container
-	tags *TagsMap
+	// Tags is a the metadata of the container
+	tags []string
 	// options
 	options *TagsMap
 }
@@ -35,18 +35,18 @@ type PURuntimeJSON struct {
 	Name string
 	// IPAddress is the IP Address of the container
 	IPAddresses *IPMap
-	// Tags is a map of the metadata of the container
-	Tags *TagsMap
+	// Tags is a list of the metadata of the container
+	Tags []string
 	// Options is a map of the options of the container
 	Options *TagsMap
 }
 
 // NewPURuntime Generate a new RuntimeInfo
-func NewPURuntime(name string, pid int, tags *TagsMap, ips *IPMap, puType constants.PUType, options *TagsMap) *PURuntime {
+func NewPURuntime(name string, pid int, tags []string, ips *IPMap, puType constants.PUType, options *TagsMap) *PURuntime {
 
 	t := tags
 	if t == nil {
-		t = NewTagsMap(nil)
+		t = []string{}
 	}
 
 	i := ips
@@ -81,7 +81,7 @@ func (r *PURuntime) Clone() *PURuntime {
 	r.puRuntimeMutex.Lock()
 	defer r.puRuntimeMutex.Unlock()
 
-	return NewPURuntime(r.name, r.pid, r.tags.Clone(), r.ips.Clone(), r.puType, r.options)
+	return NewPURuntime(r.name, r.pid, r.tags , r.ips.Clone(), r.puType, r.options)
 }
 
 // MarshalJSON Marshals this struct.
@@ -162,21 +162,12 @@ func (r *PURuntime) SetIPAddresses(ipa *IPMap) {
 	r.ips = ipa.Clone()
 }
 
-//Tag returns a specific tag for the processing unit
-func (r *PURuntime) Tag(key string) (string, bool) {
-	r.puRuntimeMutex.Lock()
-	defer r.puRuntimeMutex.Unlock()
-
-	tag, ok := r.tags.Get(key)
-	return tag, ok
-}
-
 //Tags returns tags for the processing unit
-func (r *PURuntime) Tags() *TagsMap {
+func (r *PURuntime) Tags() []string {
 	r.puRuntimeMutex.Lock()
 	defer r.puRuntimeMutex.Unlock()
 
-	return r.tags.Clone()
+	return r.tags 
 }
 
 // Options returns tags for the processing unit

--- a/policy/runtime.go
+++ b/policy/runtime.go
@@ -81,7 +81,7 @@ func (r *PURuntime) Clone() *PURuntime {
 	r.puRuntimeMutex.Lock()
 	defer r.puRuntimeMutex.Unlock()
 
-	return NewPURuntime(r.name, r.pid, r.tags , r.ips.Clone(), r.puType, r.options)
+	return NewPURuntime(r.name, r.pid, r.tags, r.ips.Clone(), r.puType, r.options)
 }
 
 // MarshalJSON Marshals this struct.
@@ -167,7 +167,7 @@ func (r *PURuntime) Tags() []string {
 	r.puRuntimeMutex.Lock()
 	defer r.puRuntimeMutex.Unlock()
 
-	return r.tags 
+	return r.tags
 }
 
 // Options returns tags for the processing unit

--- a/trireme_test.go
+++ b/trireme_test.go
@@ -273,7 +273,7 @@ func TestSimpleUpdate(t *testing.T) {
 	// Generate a new Policy ...
 	ipl := policy.NewIPMap(map[string]string{policy.DefaultNamespace: "127.0.0.1"})
 	tags := []string{}
-	newPolicy := policy.NewPUPolicy("", policy.Police, nil, nil, nil, nil, tags , nil, ipl, []string{"172.17.0.0/24"}, []string{}, nil)
+	newPolicy := policy.NewPUPolicy("", policy.Police, nil, nil, nil, nil, tags, nil, ipl, []string{"172.17.0.0/24"}, []string{}, nil)
 	doTestUpdate(t, trireme, tresolver, tsupervisor[constants.ContainerPU].(supervisor.TestSupervisor), tenforcer[constants.ContainerPU].(enforcer.TestPolicyEnforcer), tmonitor, contextID, runtime, newPolicy)
 }
 

--- a/trireme_test.go
+++ b/trireme_test.go
@@ -272,8 +272,8 @@ func TestSimpleUpdate(t *testing.T) {
 
 	// Generate a new Policy ...
 	ipl := policy.NewIPMap(map[string]string{policy.DefaultNamespace: "127.0.0.1"})
-	tagsMap := policy.NewTagsMap(map[string]string{enforcer.TransmitterLabel: contextID})
-	newPolicy := policy.NewPUPolicy("", policy.Police, nil, nil, nil, nil, tagsMap, nil, ipl, []string{"172.17.0.0/24"}, []string{}, nil)
+	tags := []string{}
+	newPolicy := policy.NewPUPolicy("", policy.Police, nil, nil, nil, nil, tags , nil, ipl, []string{"172.17.0.0/24"}, []string{}, nil)
 	doTestUpdate(t, trireme, tresolver, tsupervisor[constants.ContainerPU].(supervisor.TestSupervisor), tenforcer[constants.ContainerPU].(enforcer.TestPolicyEnforcer), tmonitor, contextID, runtime, newPolicy)
 }
 
@@ -328,36 +328,4 @@ func TestStop(t *testing.T) {
 		t.Errorf("Failed to start trireme")
 	}
 	doTestCreate(t, trireme, tresolver, tsupervisor[constants.ContainerPU].(supervisor.TestSupervisor), tenforcer[constants.ContainerPU].(enforcer.TestPolicyEnforcer), tmonitor, contextID, runtime)
-}
-
-func TestTransmitterLabel(t *testing.T) {
-
-	// If management ID is set, use it as the TransmitterLabel
-
-	mgmtID := "mgmt"
-	contextID := "Context"
-	containerInfo := policy.NewPUInfo(contextID, constants.ContainerPU)
-	containerInfo.Policy.ManagementID = mgmtID
-	addTransmitterLabel(contextID, containerInfo)
-	label, ok := containerInfo.Policy.Identity().Get(enforcer.TransmitterLabel)
-	if !ok {
-		t.Errorf("Expecting Transmitter label to be set but it is missing")
-	}
-	if label != mgmtID {
-		t.Errorf("Expecting Transmitter label to be set to MgmtID: %s , but was set to: %s", mgmtID, label)
-	}
-
-	// If management ID is not set, use contextID as the TransmitterLabel
-
-	contextID = "Context"
-	containerInfo = policy.NewPUInfo(contextID, constants.ContainerPU)
-	addTransmitterLabel(contextID, containerInfo)
-	label, ok = containerInfo.Policy.Identity().Get(enforcer.TransmitterLabel)
-	if !ok {
-		t.Errorf("Expecting Transmitter label to be set but it is missing")
-	}
-	if label != contextID {
-		t.Errorf("Expecting Transmitter label to be set to ContextID: %s , but was set to: %s", contextID, label)
-	}
-
 }


### PR DESCRIPTION
With this PR we will be allowing the same key to appear on multiple attributes. For example one can define gid=1000 and gid=2000 (ie a Linux process where the user belongs to multiple groups). 

This changes all internal data structures for maintaining labels to strings and they are not explicitly key/value pairs. 