### PR TITLE
Fix length of names of iptables

### DIFF
--- a/supervisor/ipsetctrl/acls.go
+++ b/supervisor/ipsetctrl/acls.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	appChainPrefix = "TRIREME-App-"
-	netChainPrefix = "TRIREME-Net-"
+	appChainPrefix = "App-"
+	netChainPrefix = "Net-"
 	allowPrefix    = "A-"
 	rejectPrefix   = "R-"
 )

--- a/supervisor/ipsetctrl/ipsetctrl_test.go
+++ b/supervisor/ipsetctrl/ipsetctrl_test.go
@@ -82,8 +82,8 @@ func TestSetPrefix(t *testing.T) {
 		Convey("With a contextID of Context and version of 1", func() {
 			app, net := i.setPrefix("Context")
 			Convey("I should get the right names", func() {
-				So(app, ShouldResemble, "TRIREME-App-Context-")
-				So(net, ShouldResemble, "TRIREME-Net-Context-")
+				So(app, ShouldResemble, "App-Context-")
+				So(net, ShouldResemble, "Net-Context-")
 			})
 		})
 	})

--- a/supervisor/iptablesctrl/iptables.go
+++ b/supervisor/iptablesctrl/iptables.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	chainPrefix    = "TRIREME-"
+	chainPrefix    = ""
 	appChainPrefix = chainPrefix + "App-"
 	netChainPrefix = chainPrefix + "Net-"
 )

--- a/supervisor/iptablesctrl/iptables_test.go
+++ b/supervisor/iptablesctrl/iptables_test.go
@@ -51,8 +51,8 @@ func TestChainName(t *testing.T) {
 		Convey("With a contextID of Context and version of 1", func() {
 			app, net := i.chainName("Context", 1)
 			Convey("I should get the right names", func() {
-				So(app, ShouldResemble, "TRIREME-App-Context-1")
-				So(net, ShouldResemble, "TRIREME-Net-Context-1")
+				So(app, ShouldResemble, "App-Context-1")
+				So(net, ShouldResemble, "Net-Context-1")
 			})
 		})
 	})
@@ -345,40 +345,40 @@ func TestUpdateRules(t *testing.T) {
 
 		Convey("I try to update with a valid default IP address ", func() {
 			iptables.MockDelete(t, func(table string, chain string, rulespec ...string) error {
-				if matchSpec("TRIREME-App-Context-0", rulespec) == nil || matchSpec("TRIREME-Net-Context-0", rulespec) == nil {
+				if matchSpec("App-Context-0", rulespec) == nil || matchSpec("Net-Context-0", rulespec) == nil {
 					return nil
 				}
 				return fmt.Errorf("Error")
 			})
 			iptables.MockClearChain(t, func(table string, chain string) error {
-				if chain == "TRIREME-App-Context-0" || chain == "TRIREME-Net-Context-0" {
+				if chain == "App-Context-0" || chain == "Net-Context-0" {
 					return nil
 				}
 				return fmt.Errorf("Error")
 			})
 			iptables.MockDeleteChain(t, func(table string, chain string) error {
-				if chain == "TRIREME-App-Context-0" || chain == "TRIREME-Net-Context-0" {
+				if chain == "App-Context-0" || chain == "Net-Context-0" {
 					return nil
 				}
 				return fmt.Errorf("Error")
 			})
 			iptables.MockAppend(t, func(table string, chain string, rulespec ...string) error {
-				if chain == "TRIREME-App-Context-1" || chain == "TRIREME-Net-Context-1" {
+				if chain == "App-Context-1" || chain == "Net-Context-1" {
 					return nil
 				}
-				if matchSpec("TRIREME-App-Context-1", rulespec) == nil || matchSpec("TRIREME-Net-Context-1", rulespec) == nil {
+				if matchSpec("App-Context-1", rulespec) == nil || matchSpec("Net-Context-1", rulespec) == nil {
 					return nil
 				}
 				return fmt.Errorf("Error")
 			})
 			iptables.MockInsert(t, func(table string, chain string, pos int, rulespec ...string) error {
-				if chain == "TRIREME-App-Context-1" || chain == "TRIREME-Net-Context-1" {
+				if chain == "App-Context-1" || chain == "Net-Context-1" {
 					return nil
 				}
 				return fmt.Errorf("Error")
 			})
 			iptables.MockNewChain(t, func(table string, chain string) error {
-				if chain == "TRIREME-App-Context-1" || chain == "TRIREME-Net-Context-1" {
+				if chain == "App-Context-1" || chain == "Net-Context-1" {
 					return nil
 				}
 				return fmt.Errorf("Error")


### PR DESCRIPTION
Chain names in iptables are restricted to 28 characters. Our current format would result in updates failing after 1000 updates. With this PR we remove the descriptive characters in the iptables to allow for millions of unique updates for long running processing units. 