### PR TITLE
Handle wrap-around of version numbers

### DIFF
--- a/supervisor/iptablesctrl/iptables.go
+++ b/supervisor/iptablesctrl/iptables.go
@@ -199,7 +199,7 @@ func (i *Instance) UpdateRules(version int, contextID string, containerInfo *pol
 
 	appChain, netChain := i.chainName(contextID, version)
 
-	oldAppChain, oldNetChain := i.chainName(contextID, version-1)
+	oldAppChain, oldNetChain := i.chainName(contextID, version^1)
 
 	//Add a new chain for this update and map all rules there
 	if err := i.addContainerChain(appChain, netChain); err != nil {

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -237,6 +237,6 @@ func (s *Config) doUpdatePU(contextID string, containerInfo *policy.PUInfo) erro
 
 func add(a, b interface{}) interface{} {
 	entry := a.(*cacheData)
-	entry.version += b.(int)
+	entry.version = (entry.version + b.(int)) % 16
 	return entry
 }

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -237,6 +237,6 @@ func (s *Config) doUpdatePU(contextID string, containerInfo *policy.PUInfo) erro
 
 func add(a, b interface{}) interface{} {
 	entry := a.(*cacheData)
-	entry.version = (entry.version + b.(int)) % 16
+	entry.version = entry.version ^ 1
 	return entry
 }


### PR DESCRIPTION
Chain versions do not need to increase forever. This creates problems for long running processes. We use XOR for the versions to limit the numbers, since we only need two. 