### PR TITLE
Docker monitor

### DIFF
--- a/enforcer/proxy/enforcerproxy.go
+++ b/enforcer/proxy/enforcerproxy.go
@@ -122,6 +122,8 @@ func (s *proxyInfo) Enforce(contextID string, puInfo *policy.PUInfo) error {
 
 	err = s.rpchdl.RemoteCall(contextID, "Server.Enforce", request, &rpcwrapper.Response{})
 	if err != nil {
+		//We can't talk to the enforcer. Kill it and restart it
+		s.prochdl.KillProcess(contextID)
 		zap.L().Error("Failed to Enforce remote enforcer", zap.Error(err))
 		return ErrEnforceFailed
 	}

--- a/enforcer/proxy/enforcerproxy.go
+++ b/enforcer/proxy/enforcerproxy.go
@@ -122,8 +122,6 @@ func (s *proxyInfo) Enforce(contextID string, puInfo *policy.PUInfo) error {
 
 	err = s.rpchdl.RemoteCall(contextID, "Server.Enforce", request, &rpcwrapper.Response{})
 	if err != nil {
-		//We can't talk to the enforcer. Kill it and restart it
-		s.prochdl.KillProcess(contextID)
 		zap.L().Error("Failed to Enforce remote enforcer", zap.Error(err))
 		return ErrEnforceFailed
 	}

--- a/monitor/dockermonitor/docker.go
+++ b/monitor/dockermonitor/docker.go
@@ -153,7 +153,8 @@ func NewDockerMonitor(
 	cli, err := initDockerClient(socketType, socketAddress)
 
 	if err != nil {
-		zap.L().Fatal("Unable to initialize Docker client", zap.Error(err))
+		zap.L().Debug("Unable to initialize Docker client", zap.Error(err))
+		return nil
 	}
 
 	d := &dockerMonitor{


### PR DESCRIPTION
Do Not crash on failure in newdockermonitor. Return nil and let the caller decide how he wants to handle this error 