### PR TITLE
Removing error returns from ip netns ls/identify/. These are failing

### DIFF
--- a/cmd/remoteenforcer/remoteenforcer_linux.go
+++ b/cmd/remoteenforcer/remoteenforcer_linux.go
@@ -115,7 +115,7 @@ func (s *Server) InitEnforcer(req rpcwrapper.Request, resp *rpcwrapper.Response)
 			zap.Error(err),
 		)
 		resp.Status = err.Error()
-		return errors.New(resp.Status)
+		//return errors.New(resp.Status)
 	}
 
 	netnsString := strings.TrimSpace(string(netns))
@@ -126,7 +126,7 @@ func (s *Server) InitEnforcer(req rpcwrapper.Request, resp *rpcwrapper.Response)
 			zap.Error(err),
 		)
 		resp.Status = "Not running in a namespace"
-		return errors.New(resp.Status)
+		//return errors.New(resp.Status)
 	}
 
 	zap.L().Debug("Remote enforcer launched",


### PR DESCRIPTION
sometimes with selinux enabled