### PR TITLE
Support for host networks in docker

### DIFF
--- a/monitor/linuxmonitor/cgnetcls/cgnetcls.go
+++ b/monitor/linuxmonitor/cgnetcls/cgnetcls.go
@@ -49,6 +49,10 @@ type netCls struct {
 // To add a new process to this cgroup we need to write to the cgroup file
 func (s *netCls) Creategroup(cgroupname string) error {
 
+	if !strings.HasPrefix(cgroupname, "/") {
+		cgroupname = "/" + cgroupname
+	}
+
 	//Create the directory structure
 	_, err := os.Stat(basePath + procs)
 	if os.IsNotExist(err) {
@@ -60,24 +64,26 @@ func (s *netCls) Creategroup(cgroupname string) error {
 
 	//Write to the notify on release file and release agent files
 
-	err = ioutil.WriteFile(basePath+releaseAgentConfFile, []byte(s.ReleaseAgentPath), 0644)
-	if err != nil {
-		return fmt.Errorf("Failed to register a release agent error %s", err.Error())
-	}
+	if s.ReleaseAgentPath != "" {
+		err = ioutil.WriteFile(basePath+releaseAgentConfFile, []byte(s.ReleaseAgentPath), 0644)
+		if err != nil {
+			return fmt.Errorf("Failed to register a release agent error %s", err.Error())
+		}
 
-	err = ioutil.WriteFile(basePath+notifyOnReleaseFile, []byte("1"), 0644)
-	if err != nil {
-		return fmt.Errorf("Failed to write to the notify file %s", err.Error())
-	}
+		err = ioutil.WriteFile(basePath+notifyOnReleaseFile, []byte("1"), 0644)
+		if err != nil {
+			return fmt.Errorf("Failed to write to the notify file %s", err.Error())
+		}
 
-	err = ioutil.WriteFile(basePath+TriremeBasePath+notifyOnReleaseFile, []byte("1"), 0644)
-	if err != nil {
-		return fmt.Errorf("Failed to write to the notify file %s", err.Error())
-	}
+		err = ioutil.WriteFile(basePath+TriremeBasePath+notifyOnReleaseFile, []byte("1"), 0644)
+		if err != nil {
+			return fmt.Errorf("Failed to write to the notify file %s", err.Error())
+		}
 
-	err = ioutil.WriteFile(basePath+TriremeBasePath+cgroupname+notifyOnReleaseFile, []byte("1"), 0644)
-	if err != nil {
-		return fmt.Errorf("Failed to write to the notify file %s", err.Error())
+		err = ioutil.WriteFile(basePath+TriremeBasePath+cgroupname+notifyOnReleaseFile, []byte("1"), 0644)
+		if err != nil {
+			return fmt.Errorf("Failed to write to the notify file %s", err.Error())
+		}
 	}
 
 	return nil
@@ -86,6 +92,10 @@ func (s *netCls) Creategroup(cgroupname string) error {
 
 //AssignMark writes the mark value to net_cls.classid file.
 func (s *netCls) AssignMark(cgroupname string, mark uint64) error {
+
+	if !strings.HasPrefix(cgroupname, "/") {
+		cgroupname = "/" + cgroupname
+	}
 
 	_, err := os.Stat(basePath + TriremeBasePath + cgroupname)
 	if os.IsNotExist(err) {
@@ -104,6 +114,10 @@ func (s *netCls) AssignMark(cgroupname string, mark uint64) error {
 
 // AddProcess adds the process to the net_cls group
 func (s *netCls) AddProcess(cgroupname string, pid int) error {
+
+	if !strings.HasPrefix(cgroupname, "/") {
+		cgroupname = "/" + cgroupname
+	}
 
 	_, err := os.Stat(basePath + TriremeBasePath + cgroupname)
 	if os.IsNotExist(err) {
@@ -125,6 +139,10 @@ func (s *netCls) AddProcess(cgroupname string, pid int) error {
 //RemoveProcess removes the process from the cgroup by writing the pid to the
 //top of net_cls cgroup cgroup.procs
 func (s *netCls) RemoveProcess(cgroupname string, pid int) error {
+
+	if !strings.HasPrefix(cgroupname, "/") {
+		cgroupname = "/" + cgroupname
+	}
 
 	_, err := os.Stat(basePath + TriremeBasePath + cgroupname)
 	if os.IsNotExist(err) {
@@ -148,6 +166,10 @@ func (s *netCls) RemoveProcess(cgroupname string, pid int) error {
 // Before we try deletion
 func (s *netCls) DeleteCgroup(cgroupname string) error {
 
+	if !strings.HasPrefix(cgroupname, "/") {
+		cgroupname = "/" + cgroupname
+	}
+
 	_, err := os.Stat(basePath + TriremeBasePath + cgroupname)
 	if os.IsNotExist(err) {
 		zap.L().Debug("Group already deleted", zap.Error(err))
@@ -164,6 +186,10 @@ func (s *netCls) DeleteCgroup(cgroupname string) error {
 
 //Deletebasepath removes the base aporeto directory which comes as a separate event when we are not managing any processes
 func (s *netCls) Deletebasepath(cgroupName string) bool {
+
+	if !strings.HasPrefix(cgroupName, "/") {
+		cgroupName = "/" + cgroupName
+	}
 
 	if cgroupName == TriremeBasePath {
 		os.Remove(basePath + cgroupName)
@@ -203,6 +229,18 @@ func mountCgroupController() {
 
 	}
 
+}
+
+// NewDockerCgroupNetController returns a handle to call functions on the cgroup net_cls controller
+func NewDockerCgroupNetController() Cgroupnetcls {
+
+	controller := &netCls{
+		markchan:         make(chan uint64),
+		ReleaseAgentPath: "",
+	}
+
+	mountCgroupController()
+	return controller
 }
 
 //NewCgroupNetController returns a handle to call functions on the cgroup net_cls controller

--- a/monitor/linuxmonitor/cgnetcls/cgnetcls_osx.go
+++ b/monitor/linuxmonitor/cgnetcls/cgnetcls_osx.go
@@ -60,6 +60,12 @@ func NewCgroupNetController(releasePath string) Cgroupnetcls {
 	return &netCls{}
 }
 
+//NewDockerCgroupNetController returns a handle to call functions on the cgroup net_cls controller
+func NewDockerCgroupNetController() Cgroupnetcls {
+
+	return &netCls{}
+}
+
 // MarkVal returns a new Mark
 func MarkVal() uint64 {
 	return 0

--- a/policy/runtime.go
+++ b/policy/runtime.go
@@ -121,6 +121,11 @@ func (r *PURuntime) SetPid(pid int) {
 	r.pid = pid
 }
 
+// SetPUType sets the PU Type
+func (r *PURuntime) SetPUType(puType constants.PUType) {
+	r.puType = puType
+}
+
 // SetOptions sets the Options
 func (r *PURuntime) SetOptions(options *TagsMap) {
 	r.options = options


### PR DESCRIPTION
With this PR Trireme will support networks with the host namespace (ie docker with --net=host). This enables several new use cases. 

The implementation is done by reverting to a Linux Process based support and attaching the Pid of the Docker container to a specific net_cls group. This does not interfere with Docker when --net=host. 

