### PR TITLE
Fixed: Pass proper error when returning

### DIFF
--- a/enforcer/datapath_tcp.go
+++ b/enforcer/datapath_tcp.go
@@ -797,7 +797,7 @@ func (d *Datapath) netRetrieveState(p *packet.Packet) (*PUContext, *TCPConnectio
 		}
 	} else {
 		if uerr := updateTimer(d.netReplyConnectionTracker, hash, conn.(*TCPConnection)); uerr != nil {
-			return nil, nil, err
+			return nil, nil, uerr
 		}
 	}
 


### PR DESCRIPTION
Hit this panic today. We were not passing the correct error during one of the returns from `netRetrieveState`

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x827caf]

goroutine 109 [running]:
github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme/enforcer.(*Datapath).processNetworkTCPPackets(0xc42033ef00, 0xc42688cf70, 0x0, 0x0)
	/tmp/build/80754af9/go/src/github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme/enforcer/datapath_tcp.go:71 +0x54f
github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme/enforcer.(*Datapath).processNetworkPacketsFromNFQ(0xc42033ef00, 0xc424ecb810)
	/tmp/build/80754af9/go/src/github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme/enforcer/nfq_linux.go:93 +0xdd
github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme/enforcer.networkCallback(0xc424ecb810, 0xab9120, 0xc42033ef00)
	/tmp/build/80754af9/go/src/github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme/enforcer/nfq_linux.go:19 +0x46
github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/nfqueue-go.(*NfQueue).ProcessPackets(0xc422652b40)
	/tmp/build/80754af9/go/src/github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/nfqueue-go/nfqueue.go:465 +0x313
created by github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/nfqueue-go.CreateAndStartNfQueue
	/tmp/build/80754af9/go/src/github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/nfqueue-go/nfqueue.go:117 +0x6ba
Initializing remote with fq &{QueueSeparation:false MarkValue:1000 NetworkQueue:4 NumberOfApplicationQueues:4 NumberOfNetworkQueues:4 ApplicationQueue:0 ApplicationQueueSize:500 NetworkQueueSize:500 NetworkQueuesSynStr:4:7 NetworkQueuesAckStr:4:7 NetworkQueuesSynAckStr:4:7 NetworkQueuesSvcStr:4:7 ApplicationQueuesSynStr:0:3 ApplicationQueuesAckStr:0:3 ApplicationQueuesSvcStr:0:3 ApplicationQueuesSynAckStr:0:3}
```