### PR TITLE
Make trireme event processing parallel

### DIFF
--- a/enforcer/utils/rpcwrapper/rpc_handle.go
+++ b/enforcer/utils/rpcwrapper/rpc_handle.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/gob"
 	"fmt"
+	"sync"
 
 	"go.uber.org/zap"
 
@@ -32,6 +33,8 @@ type RPCHdl struct {
 type RPCWrapper struct {
 	rpcClientMap *cache.Cache
 	contextList  []string
+
+	sync.Mutex
 }
 
 // NewRPCWrapper creates a new rpcwrapper
@@ -71,7 +74,10 @@ func (r *RPCWrapper) NewRPCClient(contextID string, channel string, sharedsecret
 		client, err = rpc.DialHTTP("unix", channel)
 	}
 
+	r.Lock()
 	r.contextList = append(r.contextList, contextID)
+	r.Unlock()
+
 	return r.rpcClientMap.Add(contextID, &RPCHdl{Client: client, Channel: channel, Secret: sharedsecret})
 
 }
@@ -203,7 +209,13 @@ func (r *RPCWrapper) DestroyRPCClient(contextID string) {
 
 // ContextList returns the list of active context managed by the rpcwrapper
 func (r *RPCWrapper) ContextList() []string {
-	return r.contextList
+	r.Lock()
+	defer r.Unlock()
+
+	rc := []string{}
+	copy(rc, r.contextList)
+
+	return rc
 }
 
 // ProcessMessage checks if the given request is valid

--- a/monitor/dockermonitor/docker.go
+++ b/monitor/dockermonitor/docker.go
@@ -291,15 +291,16 @@ func (d *dockerMonitor) eventProcessor() {
 			if event.Action != "" {
 				f, present := d.handlers[DockerEvent(event.Action)]
 				if present {
+					go func(event *events.Message) {
+						err := f(event)
 
-					err := f(event)
-
-					if err != nil {
-						zap.L().Error("Error while handling event",
-							zap.String("action", event.Action),
-							zap.Error(err),
-						)
-					}
+						if err != nil {
+							zap.L().Error("Error while handling event",
+								zap.String("action", event.Action),
+								zap.Error(err),
+							)
+						}
+					}(event)
 				} else {
 					zap.L().Debug("Docker event not handled.", zap.String("action", event.Action))
 				}

--- a/supervisor/proxy/supervisorproxy.go
+++ b/supervisor/proxy/supervisorproxy.go
@@ -66,7 +66,9 @@ func (s *ProxyInfo) Supervise(contextID string, puInfo *policy.PUInfo) error {
 	}
 
 	if err := s.rpchdl.RemoteCall(contextID, "Server.Supervise", req, &rpcwrapper.Response{}); err != nil {
+		s.Lock()
 		delete(s.initDone, contextID)
+		s.Unlock()
 		return fmt.Errorf("Failed to send supervise command: context=%s error=%s", contextID, err)
 	}
 

--- a/trireme.go
+++ b/trireme.go
@@ -2,6 +2,7 @@ package trireme
 
 import (
 	"fmt"
+	"runtime"
 
 	"go.uber.org/zap"
 
@@ -413,6 +414,9 @@ func (t *trireme) Supervisor(kind constants.PUType) supervisor.Supervisor {
 
 // run is the main function for running Trireme
 func (t *trireme) run() {
+
+	concurrency := runtime.NumCPU() - 1
+	sem := make(chan bool, concurrency)
 	for {
 		select {
 		case req := <-t.requests:
@@ -420,7 +424,13 @@ func (t *trireme) run() {
 				zap.Int("type", req.reqType),
 				zap.String("contextID", req.contextID),
 			)
-			req.returnChan <- t.handleRequest(req)
+
+			sem <- true
+			go func(req *triremeRequest) {
+				req.returnChan <- t.handleRequest(req)
+				<-sem
+			}(req)
+
 		case <-t.stop:
 			zap.L().Debug("Stopping trireme worker.")
 			return

--- a/trireme.go
+++ b/trireme.go
@@ -2,7 +2,6 @@ package trireme
 
 import (
 	"fmt"
-	"runtime"
 
 	"go.uber.org/zap"
 
@@ -415,7 +414,7 @@ func (t *trireme) Supervisor(kind constants.PUType) supervisor.Supervisor {
 // run is the main function for running Trireme
 func (t *trireme) run() {
 
-	concurrency := runtime.NumCPU() - 1
+	concurrency := 10
 	sem := make(chan bool, concurrency)
 	for {
 		select {


### PR DESCRIPTION
This PR makes the event processing in Trireme parallel and allows multiple container requests to be processed at the same time, significantly improving performance. Since we still rely on exec for the iptables rules, we restrict the parallelism to the number of cores in the machine to avoid the Go runtime going wild with threads. 