### PR TITLE
Fixes #321 : Ignore subsequent enforce requests once enforcer has exited

### DIFF
--- a/cmd/remoteenforcer/remoteenforcer_linux.go
+++ b/cmd/remoteenforcer/remoteenforcer_linux.go
@@ -52,7 +52,6 @@ type Server struct {
 	statsclient    *StatsClient
 	procMountPoint string
 	Enforcer       enforcer.PolicyEnforcer
-	ExitFlag       bool
 	Supervisor     supervisor.Supervisor
 	Service        enforcer.PacketProcessor
 	secrets        secrets.Secrets
@@ -347,11 +346,6 @@ func (s *Server) Unsupervise(req rpcwrapper.Request, resp *rpcwrapper.Response) 
 //Enforce this method calls the enforce method on the enforcer created during initenforcer
 func (s *Server) Enforce(req rpcwrapper.Request, resp *rpcwrapper.Response) error {
 
-	if s.ExitFlag {
-		zap.L().Debug("Ignoring request as enforcer already exited")
-		return nil
-	}
-
 	if !s.rpchdl.CheckValidity(&req, s.rpcSecret) {
 		resp.Status = ("Enforce Message Auth Failed")
 		return errors.New(resp.Status)
@@ -423,7 +417,6 @@ func (s *Server) EnforcerExit(req rpcwrapper.Request, resp *rpcwrapper.Response)
 	s.Supervisor = nil
 	s.Enforcer = nil
 	s.statsclient = nil
-	s.ExitFlag = true
 
 	if len(msgErrors) > 0 {
 		return fmt.Errorf(msgErrors)

--- a/enforcer/utils/rpcwrapper/rpc_handle.go
+++ b/enforcer/utils/rpcwrapper/rpc_handle.go
@@ -184,22 +184,26 @@ func (r *RPCWrapper) StartServer(protocol string, path string, handler interface
 // DestroyRPCClient calls close on the rpc and cleans up the connection
 func (r *RPCWrapper) DestroyRPCClient(contextID string) {
 
-	rpcHdl, _ := r.rpcClientMap.Get(contextID)
-	if err := rpcHdl.(*RPCHdl).Client.Close(); err != nil {
+	rpcHdl, err := r.rpcClientMap.Get(contextID)
+	if err != nil {
+		return
+	}
+
+	if err = rpcHdl.(*RPCHdl).Client.Close(); err != nil {
 		zap.L().Warn("Failed to close channel",
 			zap.String("contextID", contextID),
 			zap.Error(err),
 		)
 	}
 
-	if err := os.Remove(rpcHdl.(*RPCHdl).Channel); err != nil {
+	if err = os.Remove(rpcHdl.(*RPCHdl).Channel); err != nil {
 		zap.L().Debug("Failed to remove channel - already closed",
 			zap.String("contextID", contextID),
 			zap.Error(err),
 		)
 	}
 
-	if err := r.rpcClientMap.Remove(contextID); err != nil {
+	if err = r.rpcClientMap.Remove(contextID); err != nil {
 		zap.L().Warn("Failed to remove item from cache",
 			zap.String("contextID", contextID),
 			zap.Error(err),


### PR DESCRIPTION
I believe this will resolve the issue of trying to enforce an enofrcer that has already gracefully exited. This also fixes the panic in #321.