### PR TITLE
Fixes #323 : Retry RPC call if resource temporarily unavailable

### DIFF
--- a/cmd/systemdutil/systemdutil.go
+++ b/cmd/systemdutil/systemdutil.go
@@ -84,7 +84,7 @@ func ExecuteCommand(arguments map[string]interface{}) error {
 		return err
 	}
 
-	// Make RPC call and only retry for a few seconds if resource is temporarily unavailable
+	// Make RPC call and only retry if the resource is temporarily unavailable
 	numRetries := 0
 	client, err := net.Dial("unix", rpcmonitor.DefaultRPCAddress)
 	for err != nil {

--- a/cmd/systemdutil/systemdutil.go
+++ b/cmd/systemdutil/systemdutil.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/aporeto-inc/trireme/constants"
 	"github.com/aporeto-inc/trireme/monitor"
@@ -19,6 +20,7 @@ import (
 )
 
 const (
+	maxRetries       = 4
 	remoteMethodCall = "Server.HandleEvent"
 )
 
@@ -82,13 +84,21 @@ func ExecuteCommand(arguments map[string]interface{}) error {
 		return err
 	}
 
-	// Make RPC call
+	// Make RPC call and only retry for a few seconds if resource is temporarily unavailable
+	numRetries := 0
 	client, err := net.Dial("unix", rpcmonitor.DefaultRPCAddress)
+	for err != nil {
+		numRetries++
+		nerr, ok := err.(*net.OpError)
 
-	if err != nil {
-		err = fmt.Errorf("Cannot connect to policy process %s", err)
-		stderrlogger.Print(err)
-		return err
+		if numRetries >= maxRetries || !(ok && nerr.Err == syscall.EAGAIN) {
+			err = fmt.Errorf("Cannot connect to policy process %s", err)
+			stderrlogger.Print(err)
+			return err
+		}
+
+		time.Sleep(5 * time.Millisecond)
+		client, err = net.Dial("unix", rpcmonitor.DefaultRPCAddress)
 	}
 
 	//This is added since the release_notification comes in this format


### PR DESCRIPTION
This is a fix for #323 and should retry a few times iff the error is `EAGAIN`