### PR TITLE
Serialize control

### DIFF
--- a/policy/interfaces.go
+++ b/policy/interfaces.go
@@ -34,6 +34,7 @@ type RuntimeReader interface {
 
 	// IPAddresses returns a copy of all the IP addresses.
 	IPAddresses() ExtendedMap
-	//Returns the PUType for the PU
+
+	// Returns the PUType for the PU
 	PUType() constants.PUType
 }

--- a/policy/runtime.go
+++ b/policy/runtime.go
@@ -22,6 +22,10 @@ type PURuntime struct {
 	// options
 	options ExtendedMap
 
+	// GlobalLock is used by Trireme to make sure that two operations do not
+	// get interleaved for the same container.
+	GlobalLock *sync.Mutex
+
 	sync.Mutex
 }
 
@@ -60,12 +64,13 @@ func NewPURuntime(name string, pid int, tags *TagStore, ips ExtendedMap, puType 
 	}
 
 	return &PURuntime{
-		puType:  puType,
-		tags:    t,
-		ips:     i,
-		options: o,
-		pid:     pid,
-		name:    name,
+		puType:     puType,
+		tags:       t,
+		ips:        i,
+		options:    o,
+		pid:        pid,
+		name:       name,
+		GlobalLock: &sync.Mutex{},
 	}
 }
 


### PR DESCRIPTION
#### Description
Introduce a global lock to serialize control for a given PU. Interleaving enforcer control
and supervisor control could lead to race conditions. A given PU is only controlled 
by one trigger event at any given time. 

