### PR TITLE
Fixed: Do not try to collect flow event if error

### DIFF
--- a/enforcer/nflog_linux.go
+++ b/enforcer/nflog_linux.go
@@ -49,6 +49,7 @@ func (a *nfLog) sourceNFLogsHanlder(buf *nflog.NfPacket, data interface{}) {
 	record, err := a.recordFromNFLogBuffer(buf, false)
 	if err != nil {
 		zap.L().Error("sourceNFLogsHanlder: create flow record", zap.Error(err))
+		return
 	}
 
 	a.collector.CollectFlowEvent(record)
@@ -59,6 +60,7 @@ func (a *nfLog) destNFLogsHandler(buf *nflog.NfPacket, data interface{}) {
 	record, err := a.recordFromNFLogBuffer(buf, true)
 	if err != nil {
 		zap.L().Error("destNFLogsHandler: create flow record", zap.Error(err))
+		return
 	}
 
 	a.collector.CollectFlowEvent(record)


### PR DESCRIPTION
#### Description
Fixes the following panic and another potential one:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x7714db]

goroutine 119 [running]:
github.com/aporeto-inc/enforcerd/collector.(*PUEventCollector).cacheFlow(0xc421187d70, 0x0)
	/tmp/build/80754af9/go/src/github.com/aporeto-inc/enforcerd/collector/statscache.go:69 +0x9b
github.com/aporeto-inc/enforcerd/collector.(*PUEventCollector).CollectFlowEvent(0xc421187d70, 0x0)
	/tmp/build/80754af9/go/src/github.com/aporeto-inc/enforcerd/collector/collector.go:60 +0x35
github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme/enforcer.(*nfLog).destNFLogsHandler(0xc42170ec80, 0xc4242a1c20, 0x0, 0x0)
	/tmp/build/80754af9/go/src/github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme/enforcer/nflog_linux.go:64 +0x97
github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme/enforcer.(*nfLog).(github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme/enforcer.destNFLogsHandler)-fm(0xc4242a1c20, 0x0, 0x0)
	/tmp/build/80754af9/go/src/github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme/enforcer/nflog_linux.go:38 +0x48
github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/netlink-go/nflog.(*NfLog).parsePacket(0xc4218177a0, 0xc421394010, 0x87, 0xfff0, 0xac95c0, 0xc42063b250)
	/tmp/build/80754af9/go/src/github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/netlink-go/nflog/nflog.go:333 +0x751
github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/netlink-go/nflog.(*NfLog).parseLog(0xc4218177a0, 0xc421394000, 0x98, 0x10000, 0x10000, 0x0)
	/tmp/build/80754af9/go/src/github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/netlink-go/nflog/nflog.go:262 +0x1e8
github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/netlink-go/nflog.(*NfLog).ReadLogs(0xc4218177a0)
	/tmp/build/80754af9/go/src/github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/netlink-go/nflog/nflog.go:237 +0x265
created by github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/netlink-go/nflog.BindAndListenForLogs
	/tmp/build/80754af9/go/src/github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/netlink-go/nflog/nflog.go:55 +0x617
```

> Fixes https://github.com/aporeto-inc/enforcerd/issues/224
