### PR TITLE
Fixed: flush the cache with delay. Fixes #350. Ref #224

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -267,8 +267,7 @@ func (c *Cache) RemoveWithDelay(u interface{}, duration time.Duration) error {
 		return fmt.Errorf("Cannot remove item with delay - it doesn't exist")
 	}
 
-	var timer *time.Timer
-	timer = time.AfterFunc(duration, func() {
+	timer := time.AfterFunc(duration, func() {
 		if err := c.Remove(u); err != nil {
 			zap.L().Warn("Failed to remove item with delay", zap.String("key", fmt.Sprintf("%v", u)), zap.String("delay", duration.String()))
 		}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -323,3 +323,43 @@ func TestThousandsOfTimers(t *testing.T) {
 		})
 	})
 }
+
+func TestRemoveWithDelay(t *testing.T) {
+	Convey("Given an initial cache that is non empty", t, func() {
+		c := NewCache()
+		c.Add("info1", "info1") // nolint
+		c.Add("info2", "info2") // nolint
+		c.Add("info3", "info3") // nolint
+		c.Add("info4", "info4") // nolint
+
+		Convey("When I remove an valid entry with a duration of -1", func() {
+			err := c.RemoveWithDelay("info1", -1)
+			Convey("It should remove the entry right away", func() {
+				So(err, ShouldBeNil)
+				So(c.SizeOf(), ShouldEqual, 3)
+				_, err := c.Get("info1")
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+		Convey("When I remove an valid entry with a duration of 2 seconds", func() {
+			err := c.RemoveWithDelay("info2", 2*time.Second)
+			Convey("It should remove the entry right away", func() {
+				So(err, ShouldBeNil)
+				So(c.SizeOf(), ShouldEqual, 4)
+				<-time.After(3 * time.Second)
+				So(c.SizeOf(), ShouldEqual, 3)
+				_, err := c.Get("info2")
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+		Convey("When I remove an unknown entry with a duration of 2 seconds", func() {
+			err := c.RemoveWithDelay("unknown", 2*time.Second)
+			Convey("It should return an error", func() {
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+	})
+}

--- a/enforcer/datapath.go
+++ b/enforcer/datapath.go
@@ -215,7 +215,7 @@ func (d *Datapath) Unenforce(contextID string) error {
 		}
 	}
 
-	if err := d.contextTracker.Remove(contextID); err != nil {
+	if err := d.contextTracker.RemoveWithDelay(contextID, 10*time.Second); err != nil {
 		zap.L().Warn("Unable to remove context from cache",
 			zap.String("contextID", contextID),
 			zap.Error(err),


### PR DESCRIPTION
#### Description
This PR adds a new method named `RemoveWithDelay` on a cache instance. When a PU is removed, the contextTracker cache is now removed with a delay of 10 sec. This is fixing the missed collection flow we had last week.

#### Test plan
Unit tests have been added on the cache object itself.

> Fixes #350 
