### PR TITLE
Fix: Explicit error message for AutodetectionCache misses

### DIFF
--- a/enforcer/datapath_tcp.go
+++ b/enforcer/datapath_tcp.go
@@ -477,7 +477,7 @@ func (d *Datapath) processNetworkSynPacket(context *PUContext, conn *TCPConnecti
 		plc, perr := context.NetworkACLS.GetMatchingAction(tcpPacket.SourceAddress.To4(), tcpPacket.DestinationPort)
 		d.reportExternalServiceFlow(context, plc, false, tcpPacket)
 		if perr != nil || plc.Action == policy.Reject {
-			return nil, nil, fmt.Errorf("No Auth option on Network Syn. Drop it")
+			return nil, nil, fmt.Errorf("No Auth or ACLS - drop outgoing connection ")
 		}
 
 		conn.SetState(TCPData)
@@ -566,7 +566,7 @@ func (d *Datapath) processNetworkSynAckPacket(context *PUContext, conn *TCPConne
 		plc, err = context.ApplicationACLs.GetMatchingAction(tcpPacket.SourceAddress.To4(), tcpPacket.SourcePort)
 		if err != nil || plc.Action&policy.Reject > 0 {
 			d.reportExternalServiceFlow(context, plc, true, tcpPacket)
-			return nil, nil, fmt.Errorf("No Auth option on Network SynAck. Drop it")
+			return nil, nil, fmt.Errorf("No Auth or ACLs - Drop SynAck packet and connection")
 		}
 
 		// Added to the cache if we can accept it

--- a/enforcer/datapath_tcp.go
+++ b/enforcer/datapath_tcp.go
@@ -477,7 +477,7 @@ func (d *Datapath) processNetworkSynPacket(context *PUContext, conn *TCPConnecti
 		plc, perr := context.NetworkACLS.GetMatchingAction(tcpPacket.SourceAddress.To4(), tcpPacket.DestinationPort)
 		d.reportExternalServiceFlow(context, plc, false, tcpPacket)
 		if perr != nil || plc.Action == policy.Reject {
-			return nil, nil, fmt.Errorf("No Auth option on NetworkSyn. Drop it")
+			return nil, nil, fmt.Errorf("No Auth option on Network Syn. Drop it")
 		}
 
 		conn.SetState(TCPData)

--- a/enforcer/datapath_tcp.go
+++ b/enforcer/datapath_tcp.go
@@ -477,7 +477,7 @@ func (d *Datapath) processNetworkSynPacket(context *PUContext, conn *TCPConnecti
 		plc, perr := context.NetworkACLS.GetMatchingAction(tcpPacket.SourceAddress.To4(), tcpPacket.DestinationPort)
 		d.reportExternalServiceFlow(context, plc, false, tcpPacket)
 		if perr != nil || plc.Action == policy.Reject {
-			return nil, nil, fmt.Errorf("Drop it")
+			return nil, nil, fmt.Errorf("No Auth option on NetworkSyn. Drop it")
 		}
 
 		conn.SetState(TCPData)
@@ -566,13 +566,13 @@ func (d *Datapath) processNetworkSynAckPacket(context *PUContext, conn *TCPConne
 		plc, err = context.ApplicationACLs.GetMatchingAction(tcpPacket.SourceAddress.To4(), tcpPacket.SourcePort)
 		if err != nil || plc.Action&policy.Reject > 0 {
 			d.reportExternalServiceFlow(context, plc, true, tcpPacket)
-			return nil, nil, fmt.Errorf("Drop it")
+			return nil, nil, fmt.Errorf("No Auth option on Network SynAck. Drop it")
 		}
 
 		// Added to the cache if we can accept it
 		if err = context.externalIPCache.Add(tcpPacket.SourceAddress.String()+":"+strconv.Itoa(int(tcpPacket.SourcePort)), plc); err != nil {
 			d.releaseFlow(context, plc, tcpPacket)
-			return nil, nil, fmt.Errorf("Drop it")
+			return nil, nil, fmt.Errorf("Couldn't add to the cache %s", err)
 		}
 
 		// Set the state to Data so the other state machines ignore subsequent packets


### PR DESCRIPTION
This PR replaces the `Drop It` error with a clear Error explaining the reason of the drop