### PR TITLE
Improve ack handling

### DIFF
--- a/enforcer/connection.go
+++ b/enforcer/connection.go
@@ -91,6 +91,9 @@ type TCPConnection struct {
 
 	// FlowPolicy holds the last matched policy
 	FlowPolicy *policy.FlowPolicy
+
+	// ExpectedAckInitialSequenceNumber is the sequence number of the first ACK
+	ExpectedAckInitialSequenceNumber uint32
 }
 
 // TCPConnectionExpirationNotifier handles processing the expiration of an element

--- a/enforcer/connection.go
+++ b/enforcer/connection.go
@@ -91,9 +91,6 @@ type TCPConnection struct {
 
 	// FlowPolicy holds the last matched policy
 	FlowPolicy *policy.FlowPolicy
-
-	// ExpectedAckInitialSequenceNumber is the sequence number of the first ACK
-	ExpectedAckInitialSequenceNumber uint32
 }
 
 // TCPConnectionExpirationNotifier handles processing the expiration of an element

--- a/enforcer/datapath_tcp.go
+++ b/enforcer/datapath_tcp.go
@@ -567,7 +567,6 @@ func (d *Datapath) processNetworkSynAckPacket(context *PUContext, conn *TCPConne
 
 	// Packets with no authorization are processed as external services based on the ACLS
 	if err = tcpPacket.CheckTCPAuthenticationOption(TCPAuthenticationOptionBaseLen); err != nil {
-		fmt.Println("I received a  SYNACK and my state is  ", conn.GetState())
 		var plc *policy.FlowPolicy
 
 		flowHash := tcpPacket.SourceAddress.String() + ":" + strconv.Itoa(int(tcpPacket.SourcePort))
@@ -726,7 +725,6 @@ func (d *Datapath) processNetworkAckPacket(context *PUContext, conn *TCPConnecti
 		return nil, nil, nil
 	}
 
-	fmt.Println(" I received an ACK , but didn't process it yet ")
 	if conn.ServiceConnection {
 		return nil, nil, nil
 	}
@@ -978,7 +976,6 @@ func (d *Datapath) netSynAckRetrieveState(p *packet.Packet) (*PUContext, *TCPCon
 
 // netRetrieveState retrieves the state of a network connection. Use the flow caches for that
 func (d *Datapath) netRetrieveState(p *packet.Packet) (*PUContext, *TCPConnection, error) {
-	fmt.Println("I am looking for thestate ")
 	hash := p.L4FlowHash()
 
 	conn, err := d.netReplyConnectionTracker.GetReset(hash, 0)
@@ -1003,7 +1000,6 @@ func (d *Datapath) netRetrieveState(p *packet.Packet) (*PUContext, *TCPConnectio
 		return nil, nil, fmt.Errorf("No context found")
 	}
 
-	fmt.Println("I Found the state for htepacket ")
 	return context, conn.(*TCPConnection), nil
 
 }

--- a/enforcer/datapath_tcp.go
+++ b/enforcer/datapath_tcp.go
@@ -276,7 +276,8 @@ func (d *Datapath) processApplicationTCPPacket(tcpPacket *packet.Packet, context
 // processApplicationSynPacket processes a single Syn Packet
 func (d *Datapath) processApplicationSynPacket(tcpPacket *packet.Packet, context *PUContext, conn *TCPConnection) (interface{}, error) {
 
-	// if destination is in the cache, allow
+	// First check if the destination is in the external servicess approved cache
+	// and if yes, allow the packet to go.
 	context.Lock()
 	if policy, err := context.externalIPCache.Get(tcpPacket.DestinationAddress.String() + ":" + strconv.Itoa(int(tcpPacket.DestinationPort))); err == nil {
 		context.Unlock()
@@ -285,6 +286,8 @@ func (d *Datapath) processApplicationSynPacket(tcpPacket *packet.Packet, context
 		return policy, nil
 	}
 	context.Unlock()
+
+	// We are now processing as a Trireme packet that needs authorization headers
 
 	// Create TCP Option
 	tcpOptions := d.createTCPAuthenticationOption([]byte{})
@@ -296,16 +299,16 @@ func (d *Datapath) processApplicationSynPacket(tcpPacket *packet.Packet, context
 	if err != nil {
 		return nil, err
 	}
-	// Track the connection/port cache
-	hash := tcpPacket.L4FlowHash()
-	conn.SetState(TCPSynSend)
-	conn.ExpectedAckInitialSequenceNumber = tcpPacket.TCPSeq + 1
 
-	// conntrack
+	// Set the state indicating that we send out a Syn packet
+	conn.SetState(TCPSynSend)
+
+	// Poplate the caches to track the connection
+	hash := tcpPacket.L4FlowHash()
 	d.appOrigConnectionTracker.AddOrUpdate(hash, conn)
 	d.sourcePortConnectionCache.AddOrUpdate(tcpPacket.SourcePortHash(packet.PacketTypeApplication), conn)
 
-	// Attach the tags to the packet.
+	// Attach the tags to the packet and accept the packet
 	return nil, tcpPacket.TCPDataAttach(tcpOptions, tcpData)
 
 }
@@ -313,6 +316,10 @@ func (d *Datapath) processApplicationSynPacket(tcpPacket *packet.Packet, context
 // processApplicationSynAckPacket processes an application SynAck packet
 func (d *Datapath) processApplicationSynAckPacket(tcpPacket *packet.Packet, context *PUContext, conn *TCPConnection) (interface{}, error) {
 
+	// If we are already in the TCPData, it means that this is an external flow
+	// At this point we can release the flow to the kernel by updating conntrack
+	// We can also clean up the state since we are not going to see any more
+	// packets from this connection.
 	if conn.GetState() == TCPData && !conn.ServiceConnection {
 		if err := d.conntrackHdl.ConntrackTableUpdateMark(
 			tcpPacket.DestinationAddress.String(),
@@ -338,11 +345,11 @@ func (d *Datapath) processApplicationSynAckPacket(tcpPacket *packet.Packet, cont
 
 		return nil, nil
 	}
+
+	// We now process packets that need authorization options
 	// Process the packet at the right state. I should have either received a Syn packet or
 	// I could have send a SynAck and this is a duplicate request since my response was lost.
 	if conn.GetState() == TCPSynReceived || conn.GetState() == TCPSynAckSend {
-
-		conn.SetState(TCPSynAckSend)
 
 		// Create TCP Option
 		tcpOptions := d.createTCPAuthenticationOption([]byte{})
@@ -355,6 +362,9 @@ func (d *Datapath) processApplicationSynAckPacket(tcpPacket *packet.Packet, cont
 		if err != nil {
 			return nil, err
 		}
+
+		// Set the state for future reference
+		conn.SetState(TCPSynAckSend)
 
 		// Attach the tags to the packet
 		return nil, tcpPacket.TCPDataAttach(tcpOptions, tcpData)
@@ -372,8 +382,9 @@ func (d *Datapath) processApplicationSynAckPacket(tcpPacket *packet.Packet, cont
 // processApplicationAckPacket processes an application ack packet
 func (d *Datapath) processApplicationAckPacket(tcpPacket *packet.Packet, context *PUContext, conn *TCPConnection) (interface{}, error) {
 
-	// Only process the first Ack of a connection (same sequence number as the Syn+1)
-	if conn.ExpectedAckInitialSequenceNumber == tcpPacket.TCPSeq && tcpPacket.IsEmptyTCPPayload() {
+	// Only process the first Ack of a connection. This means that we have received
+	// as SynAck packet and we can now process the ACK.
+	if conn.GetState() == TCPSynAckReceived && tcpPacket.IsEmptyTCPPayload() {
 
 		// Create a new token that includes the source and destinatio nonse
 		// These are both challenges signed by the secret key and random for every
@@ -399,6 +410,10 @@ func (d *Datapath) processApplicationAckPacket(tcpPacket *packet.Packet, context
 
 		conn.SetState(TCPAckSend)
 
+		// If its not a service connection, we release it to the kernel. Subsequent
+		// packets after the first data packet, that might be already in the queue
+		// will be transmitted through the kernel directly. Service connections are
+		// delegated to the service module
 		if !conn.ServiceConnection && tcpPacket.SourceAddress.String() != tcpPacket.DestinationAddress.String() {
 			if err := d.conntrackHdl.ConntrackTableUpdateMark(
 				tcpPacket.SourceAddress.String(),
@@ -419,31 +434,18 @@ func (d *Datapath) processApplicationAckPacket(tcpPacket *packet.Packet, context
 		return nil, nil
 	}
 
+	// If we are already in the TCPData connection just forward the packet
 	if conn.GetState() == TCPData {
 		return nil, nil
 	}
 
+	// Here we capture the first data packet after an ACK packet by modyfing the
+	// state. We will not release the caches though to deal with re-transmissions.
+	// We will let the caches expire.
 	if conn.GetState() == TCPAckSend {
 		conn.SetState(TCPData)
 		return nil, nil
 	}
-
-	// // Catch the first request packet
-	// if conn.GetState() == TCPAckSend {
-	//
-	// 	// Once we have seen the end of the TCP SynAck sequence we have enough state
-	// 	// We can delete the source port cache to avoid any connection re-use issues
-	// 	// Flow caches will use a time out
-	// 	if err := d.sourcePortConnectionCache.Remove(tcpPacket.SourcePortHash(packet.PacketTypeApplication)); err != nil {
-	// 		zap.L().Warn("Failed to clean up cache state for connections",
-	// 			zap.String("src-port-hash", tcpPacket.SourcePortHash(packet.PacketTypeApplication)),
-	// 			zap.Error(err),
-	// 		)
-	// 	}
-	//
-	// 	conn.SetState(TCPData)
-	// 	return nil, nil
-	// }
 
 	return nil, fmt.Errorf("Received application ACK packet in the wrong state! %v", conn.GetState())
 }
@@ -478,6 +480,8 @@ func (d *Datapath) processNetworkSynPacket(context *PUContext, conn *TCPConnecti
 	context.Lock()
 	defer context.Unlock()
 
+	// Incoming packets that don't have our options are candidates to be processed
+	// as external services.
 	if err = tcpPacket.CheckTCPAuthenticationOption(TCPAuthenticationOptionBaseLen); err != nil {
 
 		// If there is no auth option, attempt the ACLs
@@ -494,6 +498,7 @@ func (d *Datapath) processNetworkSynPacket(context *PUContext, conn *TCPConnecti
 		return plc, nil, nil
 	}
 
+	// Packets that have authorization information go through the auth path
 	// Decode the JWT token using the context key
 	claims, err = d.parsePacketToken(&conn.Auth, tcpPacket.ReadTCPData())
 
@@ -556,10 +561,13 @@ func (d *Datapath) processNetworkSynPacket(context *PUContext, conn *TCPConnecti
 
 // processNetworkSynAckPacket processes a SynAck packet arriving from the network
 func (d *Datapath) processNetworkSynAckPacket(context *PUContext, conn *TCPConnection, tcpPacket *packet.Packet) (action interface{}, claims *tokens.ConnectionClaims, err error) {
+
 	context.Lock()
 	defer context.Unlock()
 
+	// Packets with no authorization are processed as external services based on the ACLS
 	if err = tcpPacket.CheckTCPAuthenticationOption(TCPAuthenticationOptionBaseLen); err != nil {
+		fmt.Println("I received a  SYNACK and my state is  ", conn.GetState())
 		var plc *policy.FlowPolicy
 
 		flowHash := tcpPacket.SourceAddress.String() + ":" + strconv.Itoa(int(tcpPacket.SourcePort))
@@ -582,24 +590,6 @@ func (d *Datapath) processNetworkSynAckPacket(context *PUContext, conn *TCPConne
 			return nil, nil, fmt.Errorf("Couldn't add to the cache %s", err)
 		}
 
-		if conn.state == TCPData {
-			// Revert the connmarks - dealing with retransmissions
-			if err := d.conntrackHdl.ConntrackTableUpdateMark(
-				tcpPacket.SourceAddress.String(),
-				tcpPacket.DestinationAddress.String(),
-				tcpPacket.IPProto,
-				tcpPacket.SourcePort,
-				tcpPacket.DestinationPort,
-				0,
-			); err != nil {
-				zap.L().Error("Failed to update conntrack table for flow",
-					zap.String("context", string(conn.Auth.LocalContext)),
-					zap.String("app-conn", tcpPacket.L4ReverseFlowHash()),
-					zap.String("state", fmt.Sprintf("%v", conn.GetState())),
-				)
-			}
-		}
-
 		// Set the state to Data so the other state machines ignore subsequent packets
 		conn.SetState(TCPData)
 
@@ -608,6 +598,30 @@ func (d *Datapath) processNetworkSynAckPacket(context *PUContext, conn *TCPConne
 		return plc, nil, nil
 	}
 
+	// This is a corner condition. We are receiving a SynAck packet and we are in
+	// a state that indicates that we have already processed one. This means that
+	// our ack packet was lost. We need to revert conntrack in this case and get
+	// back into the picture.
+	if conn.GetState() != TCPSynSend {
+
+		// Revert the connmarks - dealing with retransmissions
+		if cerr := d.conntrackHdl.ConntrackTableUpdateMark(
+			tcpPacket.SourceAddress.String(),
+			tcpPacket.DestinationAddress.String(),
+			tcpPacket.IPProto,
+			tcpPacket.SourcePort,
+			tcpPacket.DestinationPort,
+			0,
+		); cerr != nil {
+			zap.L().Error("Failed to update conntrack table for flow",
+				zap.String("context", string(conn.Auth.LocalContext)),
+				zap.String("app-conn", tcpPacket.L4ReverseFlowHash()),
+				zap.String("state", fmt.Sprintf("%v", conn.GetState())),
+			)
+		}
+	}
+
+	// Now we can process the SynAck packet with its options
 	tcpData := tcpPacket.ReadTCPData()
 	if len(tcpData) == 0 {
 		d.reportRejectedFlow(tcpPacket, nil, collector.DefaultEndPoint, context.ManagementID, context, collector.MissingToken, nil)
@@ -640,7 +654,6 @@ func (d *Datapath) processNetworkSynAckPacket(context *PUContext, conn *TCPConne
 	// We can now verify the reverse policy. The system requires that policy
 	// is matched in both directions. We have to make this optional as it can
 	// become a very strong condition
-
 	if index, _ := context.RejectTxtRules.Search(claims.T); d.mutualAuthorization && index >= 0 {
 		d.reportRejectedFlow(tcpPacket, conn, context.ManagementID, conn.Auth.RemoteContextID, context, collector.PolicyDrop, nil)
 		return nil, nil, fmt.Errorf("Dropping because of reject rule on transmitter")
@@ -713,6 +726,7 @@ func (d *Datapath) processNetworkAckPacket(context *PUContext, conn *TCPConnecti
 		return nil, nil, nil
 	}
 
+	fmt.Println(" I received an ACK , but didn't process it yet ")
 	if conn.ServiceConnection {
 		return nil, nil, nil
 	}
@@ -964,7 +978,7 @@ func (d *Datapath) netSynAckRetrieveState(p *packet.Packet) (*PUContext, *TCPCon
 
 // netRetrieveState retrieves the state of a network connection. Use the flow caches for that
 func (d *Datapath) netRetrieveState(p *packet.Packet) (*PUContext, *TCPConnection, error) {
-
+	fmt.Println("I am looking for thestate ")
 	hash := p.L4FlowHash()
 
 	conn, err := d.netReplyConnectionTracker.GetReset(hash, 0)
@@ -989,7 +1003,9 @@ func (d *Datapath) netRetrieveState(p *packet.Packet) (*PUContext, *TCPConnectio
 		return nil, nil, fmt.Errorf("No context found")
 	}
 
+	fmt.Println("I Found the state for htepacket ")
 	return context, conn.(*TCPConnection), nil
+
 }
 
 // updateTimer updates the timers for the service connections

--- a/enforcer/datapath_test.go
+++ b/enforcer/datapath_test.go
@@ -1037,8 +1037,6 @@ func TestPacketHandlingSrcPortCacheBehavior(t *testing.T) {
 			So(err2, ShouldBeNil)
 			Convey("When I pass multiple packets through the enforcer", func() {
 
-				firstAckPacketReceived := false
-
 				PacketFlow := packetgen.NewTemplateFlow()
 				PacketFlow.GenerateTCPFlow(packetgen.PacketFlowTypeGoodFlowTemplate)
 
@@ -1092,22 +1090,6 @@ func TestPacketHandlingSrcPortCacheBehavior(t *testing.T) {
 									So(es, ShouldBeNil)
 								})
 							})
-						}
-
-						// ACK Packets only
-						if tcpPacket.TCPFlags&packet.TCPSynAckMask == packet.TCPAckMask {
-							if !firstAckPacketReceived {
-								firstAckPacketReceived = true
-							} else {
-								Convey("When I pass any application packets with ACK flag for packet "+string(i), func() {
-									Convey("Then I expect src port cache to be NOT populated "+string(i), func() {
-										fmt.Println("SrcPortHash:" + tcpPacket.SourcePortHash(packet.PacketTypeApplication))
-										cs, es := enforcer.sourcePortConnectionCache.Get(tcpPacket.SourcePortHash(packet.PacketTypeApplication))
-										So(cs, ShouldBeNil)
-										So(es, ShouldNotBeNil)
-									})
-								})
-							}
 						}
 					}
 

--- a/enforcer/utils/packet/packet.go
+++ b/enforcer/utils/packet/packet.go
@@ -105,6 +105,11 @@ func New(context uint64, bytes []byte, mark string) (packet *Packet, err error) 
 	return &p, nil
 }
 
+// IsEmptyTCPPayload returns the TCP data offset
+func (p *Packet) IsEmptyTCPPayload() bool {
+	return p.TCPDataStartBytes() == p.IPTotalLength
+}
+
 // GetTCPData returns any additional data in the packet
 func (p *Packet) GetTCPData() []byte {
 	return p.tcpData

--- a/supervisor/iptablesctrl/acls.go
+++ b/supervisor/iptablesctrl/acls.go
@@ -173,12 +173,7 @@ func (i *Instance) trapRules(appChain string, netChain string) [][]string {
 			"-p", "tcp", "--tcp-flags", "SYN,ACK", "SYN",
 			"-j", "NFQUEUE", "--queue-balance", i.fqc.GetApplicationQueueSynStr(),
 		})
-		rules = append(rules, []string{
-			i.appAckPacketIPTableContext, appChain,
-			"-m", "set", "--match-set", targetNetworkSet, "dst",
-			"-p", "tcp", "--tcp-flags", "SYN,ACK", "SYN,ACK",
-			"-j", "NFQUEUE", "--queue-balance", i.fqc.GetApplicationQueueSynStr(),
-		})
+
 		// Application Packets - Evertyhing but SYN and SYN,ACK (first 4 packets). SYN,ACK is captured by global rule
 		rules = append(rules, []string{
 			i.appAckPacketIPTableContext, appChain,
@@ -197,7 +192,7 @@ func (i *Instance) trapRules(appChain string, netChain string) [][]string {
 		rules = append(rules, []string{
 			i.netPacketIPTableContext, netChain,
 			"-m", "set", "--match-set", targetNetworkSet, "src",
-			"-p", "tcp", "--tcp-flags", "SYN,ACK,PSH", "ACK",
+			"-p", "tcp", "--tcp-flags", "SYN,ACK", "ACK",
 			"-j", "NFQUEUE", "--queue-balance", i.fqc.GetNetworkQueueAckStr(),
 		})
 	}
@@ -689,6 +684,16 @@ func (i *Instance) setGlobalRules(appChain, netChain string) error {
 	err := i.ipt.Insert(
 		i.appAckPacketIPTableContext,
 		appChain, 1,
+		"-m", "connmark", "--mark", strconv.Itoa(int(constants.DefaultConnMark)),
+		"-j", "ACCEPT")
+
+	if err != nil {
+		return fmt.Errorf("Failed to add default allow for marked packets at app ")
+	}
+
+	err = i.ipt.Insert(
+		i.appAckPacketIPTableContext,
+		appChain, 1,
 		"-m", "set", "--match-set", targetNetworkSet, "dst",
 		"-p", "tcp", "--tcp-flags", "SYN,ACK", "SYN,ACK",
 		"-j", "NFQUEUE", "--queue-bypass", "--queue-balance", i.fqc.GetApplicationQueueSynAckStr())
@@ -710,32 +715,22 @@ func (i *Instance) setGlobalRules(appChain, netChain string) error {
 	err = i.ipt.Insert(
 		i.netPacketIPTableContext,
 		netChain, 1,
+		"-m", "connmark", "--mark", strconv.Itoa(int(constants.DefaultConnMark)),
+		"-j", "ACCEPT")
+
+	if err != nil {
+		return fmt.Errorf("Failed to add default allow for marked packets at net")
+	}
+
+	err = i.ipt.Insert(
+		i.netPacketIPTableContext,
+		netChain, 1,
 		"-m", "set", "--match-set", targetNetworkSet, "src",
 		"-p", "tcp", "--tcp-flags", "SYN,ACK", "SYN,ACK",
 		"-j", "NFQUEUE", "--queue-bypass", "--queue-balance", i.fqc.GetNetworkQueueSynAckStr())
 
 	if err != nil {
 		return fmt.Errorf("Failed to add capture SynAck rule for table %s, chain %s, with error: %s", i.appAckPacketIPTableContext, i.appPacketIPTableSection, err.Error())
-	}
-
-	err = i.ipt.Insert(
-		i.appAckPacketIPTableContext,
-		appChain, 1,
-		"-m", "connmark", "--mark", strconv.Itoa(int(constants.DefaultConnMark)),
-		"-j", "ACCEPT")
-
-	if err != nil {
-		return fmt.Errorf("Failed to add default allow for marked packets at app ")
-	}
-
-	err = i.ipt.Insert(
-		i.netPacketIPTableContext,
-		netChain, 1,
-		"-m", "connmark", "--mark", strconv.Itoa(int(constants.DefaultConnMark)),
-		"-j", "ACCEPT")
-
-	if err != nil {
-		return fmt.Errorf("Failed to add default allow for marked packets at net")
 	}
 
 	return nil


### PR DESCRIPTION
#### Description
This patch improves the state machines and accepts multiple failures on ACK 
and SynAck packets. 

#### Test plan
Patch was tested with manual fault injection. We need a generic framework for 
fault injection so that we can probe different sequences of packet losses. 
