### PR TITLE
Support for NewWithOption for Configurator

### DIFF
--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -57,7 +57,8 @@ type TriremeOptions struct {
 	DockerSocketType string
 	DockerSocket     string
 
-	Validity time.Duration
+	Validity                time.Duration
+	ExternalIPCacheValidity time.Duration
 
 	FilterQueue *fqconfig.FilterQueue
 
@@ -106,7 +107,8 @@ func DefaultTriremeOptions() *TriremeOptions {
 
 		Validity: time.Hour * 8760,
 
-		FilterQueue: fqconfig.NewFilterQueueWithDefaults(),
+		FilterQueue:             fqconfig.NewFilterQueueWithDefaults(),
+		ExternalIPCacheValidity: -1, // Will get the default from the instantiation.
 
 		ModeType: constants.RemoteContainer,
 		ImplType: constants.IPTables,
@@ -205,6 +207,7 @@ func NewTriremeWithOptions(options *TriremeOptions) (*TriremeResult, error) {
 			options.Validity,
 			constants.LocalContainer,
 			options.ProcMountPoint,
+			options.ExternalIPCacheValidity,
 		)
 
 		s, err = supervisor.NewSupervisor(
@@ -235,6 +238,7 @@ func NewTriremeWithOptions(options *TriremeOptions) (*TriremeResult, error) {
 			options.Validity,
 			constants.LocalServer,
 			options.ProcMountPoint,
+			options.ExternalIPCacheValidity,
 		)
 
 		s, err = supervisor.NewSupervisor(

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -124,7 +124,7 @@ func DefaultTriremeOptions() *TriremeOptions {
 		MutualAuth: false,
 
 		KillContainerError: false,
-		SyncAtStart:        false,
+		SyncAtStart:        true,
 
 		PKI: false,
 

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -180,6 +180,7 @@ func NewTriremeWithOptions(options *TriremeOptions) (*TriremeResult, error) {
 			rpcwrapper,
 			options.RemoteArg,
 			options.ProcMountPoint,
+			options.ExternalIPCacheValidity,
 		)
 
 		s, err = supervisorproxy.NewProxySupervisor(

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -39,7 +39,6 @@ const (
 type TriremeOptions struct {
 	ServerID string
 
-	RemoteEnforcer     bool
 	KillContainerError bool
 	SyncAtStart        bool
 
@@ -48,7 +47,6 @@ type TriremeOptions struct {
 	KeyPEM    []byte
 	CertPEM   []byte
 	CaCertPEM []byte
-	Token     []byte
 
 	TargetNetworks []string
 
@@ -62,15 +60,12 @@ type TriremeOptions struct {
 	DockerSocketType string
 	DockerSocket     string
 
-	ImplementationType constants.ImplementationType
-
 	MutualAuth bool
 	Validity   time.Duration
 
 	FilterQueue *fqconfig.FilterQueue
 
 	ModeType constants.ModeType
-	PUType   constants.PUType
 	ImplType constants.ImplementationType
 
 	ProcMountPoint        string

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -39,9 +39,6 @@ const (
 type TriremeOptions struct {
 	ServerID string
 
-	KillContainerError bool
-	SyncAtStart        bool
-
 	PSK []byte
 
 	KeyPEM    []byte
@@ -73,6 +70,9 @@ type TriremeOptions struct {
 
 	RemoteArg string
 
+	KillContainerError bool
+	SyncAtStart        bool
+
 	PKI bool
 
 	LocalProcess    bool
@@ -95,33 +95,38 @@ type TriremeResult struct {
 // DefaultTriremeOptions returns a default set of options.
 func DefaultTriremeOptions() *TriremeOptions {
 	return &TriremeOptions{
-		EventCollector: &collector.DefaultCollector{},
-
-		MutualAuth:  false,
-		FilterQueue: fqconfig.NewFilterQueueWithDefaults(),
-
-		Validity: time.Hour * 8760,
-
 		TargetNetworks: []string{},
+
+		EventCollector: &collector.DefaultCollector{},
 
 		DockerSocketType: constants.DefaultDockerSocketType,
 		DockerSocket:     constants.DefaultDockerSocket,
 
-		ProcMountPoint:        DefaultProcMountPoint,
-		AporetoProcMountPoint: DefaultAporetoProcMountPoint,
+		MutualAuth: false,
+		Validity:   time.Hour * 8760,
+
+		FilterQueue: fqconfig.NewFilterQueueWithDefaults(),
 
 		ModeType: constants.RemoteContainer,
 		ImplType: constants.IPTables,
 
+		ProcMountPoint:        DefaultProcMountPoint,
+		AporetoProcMountPoint: DefaultAporetoProcMountPoint,
+
 		RemoteArg: constants.DefaultRemoteArg,
+
+		KillContainerError: false,
+		SyncAtStart:        false,
 
 		PKI: false,
 
+		LocalProcess:    true,
+		LocalContainer:  false,
 		RemoteContainer: true,
+		CNI:             false,
 
+		RPCAddress:              rpcmonitor.DefaultRPCAddress,
 		LinuxProcessReleasePath: "",
-
-		RPCAddress: rpcmonitor.DefaultRPCAddress,
 	}
 }
 

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -51,8 +51,8 @@ type TriremeOptions struct {
 	EventCollector collector.EventCollector
 	Processor      enforcer.PacketProcessor
 
-	CNIMetadataExtractor    *rpcmonitor.RPCMetadataExtractor
-	DockerMetadataExtractor *dockermonitor.DockerMetadataExtractor
+	CNIMetadataExtractor    rpcmonitor.RPCMetadataExtractor
+	DockerMetadataExtractor dockermonitor.DockerMetadataExtractor
 
 	DockerSocketType string
 	DockerSocket     string
@@ -260,7 +260,7 @@ func NewTriremeWithOptions(options *TriremeOptions) (*TriremeResult, error) {
 			options.DockerSocketType,
 			options.DockerSocket,
 			triremeInstance,
-			*options.DockerMetadataExtractor,
+			options.DockerMetadataExtractor,
 			options.EventCollector,
 			options.SyncAtStart,
 			nil,
@@ -297,7 +297,7 @@ func NewTriremeWithOptions(options *TriremeOptions) (*TriremeResult, error) {
 		cniProcessor := cnimonitor.NewCniProcessor(
 			options.EventCollector,
 			triremeInstance,
-			*options.CNIMetadataExtractor)
+			options.CNIMetadataExtractor)
 		err := rpcMonitorInstance.RegisterProcessor(
 			constants.ContainerPU,
 			cniProcessor)
@@ -344,7 +344,7 @@ func NewPSKTriremeWithDockerMonitor(
 	options.SyncAtStart = syncAtStart
 	options.PKI = false
 	options.PSK = key
-	options.DockerMetadataExtractor = &dockerMetadataExtractor
+	options.DockerMetadataExtractor = dockerMetadataExtractor
 	options.LocalProcess = false
 	if remoteEnforcer {
 		options.RemoteContainer = true
@@ -398,7 +398,7 @@ func NewPKITriremeWithDockerMonitor(
 	options.KeyPEM = keyPEM
 	options.CertPEM = certPEM
 	options.CaCertPEM = caCertPEM
-	options.DockerMetadataExtractor = &dockerMetadataExtractor
+	options.DockerMetadataExtractor = dockerMetadataExtractor
 	options.LocalProcess = false
 	if remoteEnforcer {
 		options.RemoteContainer = true
@@ -447,7 +447,7 @@ func NewPSKHybridTriremeWithMonitor(
 	options.SyncAtStart = syncAtStart
 	options.PKI = false
 	options.PSK = key
-	options.DockerMetadataExtractor = &dockerMetadataExtractor
+	options.DockerMetadataExtractor = dockerMetadataExtractor
 	options.LocalProcess = true
 	options.RemoteContainer = true
 	options.LocalContainer = false

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -32,6 +32,44 @@ const (
 	AporetoProcMountPoint = "/aporetoproc"
 )
 
+// TriremeOptions defines all the possible configuration options for Trireme configurator
+type TriremeOptions struct {
+	ServerID string
+
+	RemoteEnforcer     bool
+	KillContainerError bool
+	SyncAtStart        bool
+
+	PSK []byte
+
+	KeyPEM    []byte
+	CertPEM   []byte
+	CaCertPEM []byte
+	Token     []byte
+
+	TargetNetworks []string
+
+	resolver       *trireme.PolicyResolver
+	EventCollector *collector.EventCollector
+	Processor      *enforcer.PacketProcessor
+
+	ImplementationType constants.ImplementationType
+}
+
+// TriremeResult is the result of the creation of Trireme
+type TriremeResult struct {
+}
+
+// DefaultTriremeOptions returns a default set of options.
+func DefaultTriremeOptions() *TriremeOptions {
+	return &TriremeOptions{}
+}
+
+// NewTriremeWithOptions creates all the Trireme objects based on the option struct
+func NewTriremeWithOptions(options *TriremeOptions) (*TriremeResult, error) {
+	return nil, nil
+}
+
 // NewTriremeLinuxProcess instantiates Trireme for a Linux process implementation
 func NewTriremeLinuxProcess(
 	serverID string,

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -133,8 +133,8 @@ func DefaultTriremeOptions() *TriremeOptions {
 // NewTriremeWithOptions creates all the Trireme objects based on the option struct
 func NewTriremeWithOptions(options *TriremeOptions) (*TriremeResult, error) {
 
-	var enforcers map[constants.PUType]enforcer.PolicyEnforcer
-	var supervisors map[constants.PUType]supervisor.Supervisor
+	enforcers := map[constants.PUType]enforcer.PolicyEnforcer{}
+	supervisors := map[constants.PUType]supervisor.Supervisor{}
 
 	var secretInstance secrets.Secrets
 	var dockerMonitorInstance monitor.Monitor

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -144,6 +144,7 @@ func NewTriremeWithOptions(options *TriremeOptions) (*TriremeResult, error) {
 	var dockerMonitorInstance monitor.Monitor
 	var rpcMonitorInstance *rpcmonitor.RPCMonitor
 
+	var pkiSecrets *secrets.PKISecrets
 	var err error
 
 	// Only a type of Container (remote or local) can be enabled
@@ -152,7 +153,7 @@ func NewTriremeWithOptions(options *TriremeOptions) (*TriremeResult, error) {
 	}
 
 	if options.PKI {
-		pkiSecrets, err := secrets.NewPKISecrets(options.KeyPEM, options.CertPEM, options.CaCertPEM, map[string]*ecdsa.PublicKey{})
+		pkiSecrets, err = secrets.NewPKISecrets(options.KeyPEM, options.CertPEM, options.CaCertPEM, map[string]*ecdsa.PublicKey{})
 		secretInstance = pkiSecrets
 		publicKeyAdder = pkiSecrets
 		if err != nil {
@@ -317,7 +318,7 @@ func NewTriremeWithOptions(options *TriremeOptions) (*TriremeResult, error) {
 // NewPSKTriremeWithDockerMonitor creates a new network isolator. The calling module must provide
 // a policy engine implementation and a pre-shared secret. This is for backward
 // compatibility. Will be removed
-// DEPRECATED. Use NewWithOptions
+// DEPRECATED. Use NewWithOptions instead
 func NewPSKTriremeWithDockerMonitor(
 	serverID string,
 	resolver trireme.PolicyResolver,
@@ -413,7 +414,6 @@ func NewPKITriremeWithDockerMonitor(
 	}
 
 	return trireme.Trireme, trireme.DockerMonitor, trireme.PublicKeyAdder
-
 }
 
 // NewTriremeLinuxProcess instantiates Trireme for a Linux process implementation

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -419,7 +419,8 @@ func NewPKITriremeWithDockerMonitor(
 
 	trireme, err := NewTriremeWithOptions(options)
 	if err != nil {
-		zap.L().Fatal("Error creating trireme", zap.Error(err))
+		// Respecting the convention of previous implementation (deprecated anyways)
+		return nil, nil, nil
 	}
 
 	return trireme.Trireme, trireme.DockerMonitor, trireme.PublicKeyAdder

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -306,13 +306,21 @@ func NewTriremeWithOptions(options *TriremeOptions) (*TriremeResult, error) {
 		}
 	}
 
-	return &TriremeResult{
+	result := &TriremeResult{
 		Trireme:        triremeInstance,
-		DockerMonitor:  dockerMonitorInstance,
-		RPCMonitor:     *rpcMonitorInstance,
 		PublicKeyAdder: publicKeyAdder,
 		Secret:         secretInstance,
-	}, nil
+	}
+
+	if dockerMonitorInstance != nil {
+		result.DockerMonitor = dockerMonitorInstance
+	}
+
+	if rpcMonitorInstance != nil {
+		result.RPCMonitor = *rpcMonitorInstance
+	}
+
+	return result, nil
 }
 
 // NewPSKTriremeWithDockerMonitor creates a new network isolator. The calling module must provide

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -85,7 +85,8 @@ type TriremeOptions struct {
 	RemoteContainer bool
 	CNI             bool
 
-	RPCAddress string
+	RPCAddress              string
+	LinuxProcessReleasePath string
 }
 
 // TriremeResult is the result of the creation of Trireme
@@ -122,6 +123,8 @@ func DefaultTriremeOptions() *TriremeOptions {
 		PKI: false,
 
 		RemoteContainer: true,
+
+		LinuxProcessReleasePath: "",
 
 		RPCAddress: rpcmonitor.DefaultRPCAddress,
 	}
@@ -270,16 +273,28 @@ func NewTriremeWithOptions(options *TriremeOptions) (*TriremeResult, error) {
 
 	if options.LocalProcess {
 		// configure a LinuxServices processor for the rpc monitor
-		linuxMonitorProcessor := linuxmonitor.NewLinuxProcessor(options.EventCollector, triremeInstance, linuxmonitor.SystemdRPCMetadataExtractor, "")
-		if err := rpcMonitorInstance.RegisterProcessor(constants.LinuxProcessPU, linuxMonitorProcessor); err != nil {
+		linuxMonitorProcessor := linuxmonitor.NewLinuxProcessor(
+			options.EventCollector,
+			triremeInstance,
+			linuxmonitor.SystemdRPCMetadataExtractor,
+			options.LinuxProcessReleasePath)
+		if err := rpcMonitorInstance.RegisterProcessor(
+			constants.LinuxProcessPU,
+			linuxMonitorProcessor); err != nil {
 			zap.L().Fatal("Failed to initialize RPC monitor", zap.Error(err))
 		}
 	}
 
 	if options.CNI {
 		// configure a CNI processor for the rpc monitor
-		cniProcessor := cnimonitor.NewCniProcessor(options.EventCollector, triremeInstance, *options.CNIMetadataExtractor)
-		if err := rpcMonitorInstance.RegisterProcessor(constants.ContainerPU, cniProcessor); err != nil {
+		cniProcessor := cnimonitor.NewCniProcessor(
+			options.EventCollector,
+			triremeInstance,
+			*options.CNIMetadataExtractor)
+		err := rpcMonitorInstance.RegisterProcessor(
+			constants.ContainerPU,
+			cniProcessor)
+		if err != nil {
 			zap.L().Fatal("Failed to initialize RPC monitor", zap.Error(err))
 		}
 	}

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -57,8 +57,7 @@ type TriremeOptions struct {
 	DockerSocketType string
 	DockerSocket     string
 
-	MutualAuth bool
-	Validity   time.Duration
+	Validity time.Duration
 
 	FilterQueue *fqconfig.FilterQueue
 
@@ -70,6 +69,11 @@ type TriremeOptions struct {
 
 	RemoteArg string
 
+	RPCAddress              string
+	LinuxProcessReleasePath string
+
+	MutualAuth bool
+
 	KillContainerError bool
 	SyncAtStart        bool
 
@@ -79,9 +83,6 @@ type TriremeOptions struct {
 	LocalContainer  bool
 	RemoteContainer bool
 	CNI             bool
-
-	RPCAddress              string
-	LinuxProcessReleasePath string
 }
 
 // TriremeResult is the result of the creation of Trireme
@@ -102,8 +103,7 @@ func DefaultTriremeOptions() *TriremeOptions {
 		DockerSocketType: constants.DefaultDockerSocketType,
 		DockerSocket:     constants.DefaultDockerSocket,
 
-		MutualAuth: false,
-		Validity:   time.Hour * 8760,
+		Validity: time.Hour * 8760,
 
 		FilterQueue: fqconfig.NewFilterQueueWithDefaults(),
 
@@ -115,6 +115,11 @@ func DefaultTriremeOptions() *TriremeOptions {
 
 		RemoteArg: constants.DefaultRemoteArg,
 
+		RPCAddress:              rpcmonitor.DefaultRPCAddress,
+		LinuxProcessReleasePath: "",
+
+		MutualAuth: false,
+
 		KillContainerError: false,
 		SyncAtStart:        false,
 
@@ -124,9 +129,6 @@ func DefaultTriremeOptions() *TriremeOptions {
 		LocalContainer:  false,
 		RemoteContainer: true,
 		CNI:             false,
-
-		RPCAddress:              rpcmonitor.DefaultRPCAddress,
-		LinuxProcessReleasePath: "",
 	}
 }
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -37,7 +37,7 @@ const (
 type PUType int
 
 const (
-	// ContainerPU indicates that this PU is a conctainer
+	// ContainerPU indicates that this PU is a container
 	ContainerPU PUType = iota
 	// LinuxProcessPU indicates that this is Linux process
 	LinuxProcessPU

--- a/enforcer/datapath.go
+++ b/enforcer/datapath.go
@@ -91,6 +91,8 @@ func New(
 	externalIPCacheTimeout time.Duration,
 ) PolicyEnforcer {
 
+	zap.L().Info("Using External Timrout of ", zap.Any("timeout", externalIPCacheTimeout))
+
 	if externalIPCacheTimeout <= 0 {
 		var err error
 		externalIPCacheTimeout, err = time.ParseDuration(DefaultExternalIPTimeout)

--- a/enforcer/nfq_linux.go
+++ b/enforcer/nfq_linux.go
@@ -86,7 +86,7 @@ func (d *Datapath) startApplicationInterceptor() {
 		go func(j uint16) {
 			for range d.appStop[j] {
 				//Call StopQueue
-				nfq[i].StopQueue()
+				nfq[j].StopQueue()
 				return
 			}
 

--- a/enforcer/nfq_linux.go
+++ b/enforcer/nfq_linux.go
@@ -6,6 +6,7 @@ package enforcer
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	nfqueue "github.com/aporeto-inc/netlink-go/nfqueue"
 	"github.com/aporeto-inc/trireme/enforcer/utils/packet"
@@ -39,10 +40,17 @@ func (d *Datapath) startNetworkInterceptor() {
 		// Initialize all the queues
 		nfq[i], err = nfqueue.CreateAndStartNfQueue(d.filterQueue.GetNetworkQueueStart()+i, d.filterQueue.GetNetworkQueueSize(), nfqueue.NfDefaultPacketSize, networkCallback, errorCallback, d)
 		if err != nil {
-			zap.L().Fatal("Unable to initialize netfilter queue", zap.Error(err))
+			for retry := 0; retry < 5 && err != nil; retry++ {
+				nfq[i], err = nfqueue.CreateAndStartNfQueue(d.filterQueue.GetNetworkQueueStart()+i, d.filterQueue.GetNetworkQueueSize(), nfqueue.NfDefaultPacketSize, networkCallback, errorCallback, d)
+				<-time.After(3 * time.Second)
+			}
+			if err != nil {
+				zap.L().Fatal("Unable to initialize netfilter queue", zap.Error(err))
+			}
 		}
 		go func(j uint16) {
 			for range d.netStop[j] {
+				nfq[j].StopQueue()
 				return
 			}
 		}(i)
@@ -66,10 +74,19 @@ func (d *Datapath) startApplicationInterceptor() {
 		nfq[i], err = nfqueue.CreateAndStartNfQueue(d.filterQueue.GetApplicationQueueStart()+i, d.filterQueue.GetApplicationQueueSize(), nfqueue.NfDefaultPacketSize, appCallBack, errorCallback, d)
 
 		if err != nil {
-			zap.L().Fatal("Unable to initialize netfilter queue", zap.Error(err))
+			for retry := 0; retry < 5 && err != nil; retry++ {
+				nfq[i], err = nfqueue.CreateAndStartNfQueue(d.filterQueue.GetApplicationQueueStart()+i, d.filterQueue.GetApplicationQueueSize(), nfqueue.NfDefaultPacketSize, appCallBack, errorCallback, d)
+				<-time.After(3 * time.Second)
+			}
+			if err != nil {
+				zap.L().Fatal("Unable to initialize netfilter queue", zap.Int("QueueNum", int(d.filterQueue.GetNetworkQueueStart()+i)), zap.Error(err))
+			}
+
 		}
 		go func(j uint16) {
 			for range d.appStop[j] {
+				//Call StopQueue
+				nfq[i].StopQueue()
 				return
 			}
 


### PR DESCRIPTION
This PR uses the old logic for configurator functions but also support the NewWithOptions in the Trireme configurator.

Next step is to move all the Other  `func` to use `NewWithOptions`