### PR TITLE
New: Add Support for CompactPKI when using the configurator

### DIFF
--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -156,15 +156,15 @@ func NewTriremeWithOptions(options *TriremeOptions) (*TriremeResult, error) {
 	}
 
 	if options.PKI {
-		//
 		if options.SmartToken != nil {
+
 			pkiSecrets, err = secrets.NewCompactPKI(options.KeyPEM, options.CertPEM, options.CaCertPEM, options.SmartToken)
 			if err != nil {
 				return nil, fmt.Errorf("Error Instantiating new Compact PKI: %s", err)
 			}
 		} else {
-			pkiTriremeSecret, err := secrets.NewPKISecrets(options.KeyPEM, options.CertPEM, options.CaCertPEM, map[string]*ecdsa.PublicKey{})
-			if err != nil {
+			pkiTriremeSecret, err2 := secrets.NewPKISecrets(options.KeyPEM, options.CertPEM, options.CaCertPEM, map[string]*ecdsa.PublicKey{})
+			if err2 != nil {
 				return nil, fmt.Errorf("Error Instantiating New PKI Secret: %s", err)
 			}
 			pkiSecrets = pkiTriremeSecret

--- a/configurator/configurator.go
+++ b/configurator/configurator.go
@@ -158,7 +158,9 @@ func NewTriremeWithOptions(options *TriremeOptions) (*TriremeResult, error) {
 	if options.PKI {
 		if options.SmartToken != nil {
 
+			zap.L().Info("Initializing Trireme with Smart PKI Auth")
 			pkiSecrets, err = secrets.NewCompactPKI(options.KeyPEM, options.CertPEM, options.CaCertPEM, options.SmartToken)
+			zap.L().Info("Finished Initializing Trireme with PKI Auth")
 			if err != nil {
 				return nil, fmt.Errorf("Error Instantiating new Compact PKI: %s", err)
 			}

--- a/enforcer/utils/secrets/compactpki.go
+++ b/enforcer/utils/secrets/compactpki.go
@@ -31,11 +31,14 @@ func NewCompactPKI(keyPEM, certPEM, caPEM, txKey []byte) (*CompactPKI, error) {
 	if err != nil {
 		return nil, err
 	}
+	zap.L().Debug("Finished Load And Verify")
 
 	caKey, err := crypto.LoadCertificate(caPEM)
 	if err != nil {
 		return nil, err
 	}
+
+	zap.L().Debug("Finished LoadCertificates")
 
 	if len(txKey) == 0 {
 		return nil, fmt.Errorf("TransmitToken missing")


### PR DESCRIPTION
This PR adds support for the `compactPKI` through the Configurator. 

The user can now adds a SmartToken as part of the `option` struct and as a result the secret will be created as a smartToken.