### PR TITLE
new: added support for using a different JWT signing CA.

### DIFF
--- a/cmd/remoteenforcer/remoteenforcer_linux.go
+++ b/cmd/remoteenforcer/remoteenforcer_linux.go
@@ -162,7 +162,7 @@ func (s *Server) InitEnforcer(req rpcwrapper.Request, resp *rpcwrapper.Response)
 			// PKI params
 			s.secrets, err = secrets.NewPKISecrets(payload.PrivatePEM, payload.PublicPEM, payload.CAPEM, map[string]*ecdsa.PublicKey{})
 			if err != nil {
-				return fmt.Errorf("Failed to initialize secrets")
+				return fmt.Errorf("Failed to initialize secrets: %s", err)
 			}
 			s.Enforcer = enforcer.New(
 				payload.MutualAuth,
@@ -193,9 +193,9 @@ func (s *Server) InitEnforcer(req rpcwrapper.Request, resp *rpcwrapper.Response)
 			)
 		case secrets.PKICompactType:
 			// Compact PKI Parameters
-			s.secrets, err = secrets.NewCompactPKI(payload.PrivatePEM, payload.PublicPEM, payload.CAPEM, payload.Token)
+			s.secrets, err = secrets.NewCompactPKIWithTokenCA(payload.PrivatePEM, payload.PublicPEM, payload.CAPEM, payload.TokenCAPEM, payload.Token)
 			if err != nil {
-				return fmt.Errorf("Failed to initialize secrets")
+				return fmt.Errorf("Failed to initialize secrets: %s", err)
 			}
 			s.Enforcer = enforcer.New(
 				payload.MutualAuth,
@@ -214,7 +214,7 @@ func (s *Server) InitEnforcer(req rpcwrapper.Request, resp *rpcwrapper.Response)
 			zap.L().Info("Using Null Secrets")
 			s.secrets, err = secrets.NewNullPKI(payload.PrivatePEM, payload.PublicPEM, payload.CAPEM)
 			if err != nil {
-				return fmt.Errorf("Failed to initialize secrets")
+				return fmt.Errorf("Failed to initialize secrets: %s", err)
 			}
 			s.Enforcer = enforcer.New(
 				payload.MutualAuth,

--- a/cmd/remoteenforcer/remoteenforcer_linux.go
+++ b/cmd/remoteenforcer/remoteenforcer_linux.go
@@ -193,7 +193,7 @@ func (s *Server) InitEnforcer(req rpcwrapper.Request, resp *rpcwrapper.Response)
 			)
 		case secrets.PKICompactType:
 			// Compact PKI Parameters
-			s.secrets, err = secrets.NewCompactPKIWithTokenCA(payload.PrivatePEM, payload.PublicPEM, payload.CAPEM, payload.TokenCAPEM, payload.Token)
+			s.secrets, err = secrets.NewCompactPKIWithTokenCA(payload.PrivatePEM, payload.PublicPEM, payload.CAPEM, payload.TokenKeyPEMs, payload.Token)
 			if err != nil {
 				return fmt.Errorf("Failed to initialize secrets: %s", err)
 			}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -174,7 +174,7 @@ func LoadCertificate(certPEM []byte) (*x509.Certificate, error) {
 	// Decode the certificate
 	certBlock, _ := pem.Decode(certPEM)
 	if certBlock == nil {
-		return nil, fmt.Errorf("Failed to decode PEM block")
+		return nil, fmt.Errorf("Failed to decode PEM block: %s", string(certPEM))
 	}
 
 	// Create the certificate structure

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -386,7 +386,7 @@ IG7Nv+YlTVp5qA==
 						So(key, ShouldBeNil)
 						So(cert, ShouldBeNil)
 						So(certPool, ShouldBeNil)
-						So(err, ShouldResemble, fmt.Errorf("Failed to decode PEM block"))
+						So(err, ShouldResemble, fmt.Errorf("Failed to decode PEM block: -----BEGIN CERTIFICATE-----\n\t\t-----END CERTIFICATE-----"))
 					})
 				})
 			})

--- a/enforcer/proxy/enforcerproxy.go
+++ b/enforcer/proxy/enforcerproxy.go
@@ -26,6 +26,7 @@ import (
 //PolicyEnforcer interface
 type keyPEM interface {
 	AuthPEM() []byte
+	TokenPEM() []byte
 	TransmittedPEM() []byte
 	EncodingPEM() []byte
 }
@@ -80,6 +81,7 @@ func (s *ProxyInfo) InitRemoteEnforcer(contextID string) error {
 
 	if s.Secrets.Type() == secrets.PKICompactType {
 		request.Payload.(*rpcwrapper.InitRequestPayload).Token = s.Secrets.TransmittedKey()
+		request.Payload.(*rpcwrapper.InitRequestPayload).TokenCAPEM = s.Secrets.(keyPEM).TokenPEM()
 	}
 
 	if err := s.rpchdl.RemoteCall(contextID, "Server.InitEnforcer", request, resp); err != nil {

--- a/enforcer/utils/pkiverifier/pkiverifier.go
+++ b/enforcer/utils/pkiverifier/pkiverifier.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
-	"go.uber.org/zap"
 
 	"github.com/aporeto-inc/trireme/cache"
 )
@@ -19,33 +18,49 @@ const (
 	defaultValidity = 1
 )
 
-// VerifierClaims captures all the clains of the verifier that is basically the public key
-type VerifierClaims struct {
+// PKITokenIssuer is the interface of an object that can issue a PKI token.
+type PKITokenIssuer interface {
+	CreateTokenFromCertificate(*x509.Certificate) ([]byte, error)
+}
+
+// PKITokenVerifier is the interface of an object that can verify a PKI token.
+type PKITokenVerifier interface {
+	Verify([]byte) (*ecdsa.PublicKey, error)
+}
+
+type verifierClaims struct {
 	X *big.Int
 	Y *big.Int
 	jwt.StandardClaims
 }
 
-// PKIConfiguration is the configuration of the verifier
-type PKIConfiguration struct {
-	publicKey  *ecdsa.PublicKey
+type tokenManager struct {
+	publicKeys []*ecdsa.PublicKey
 	privateKey *ecdsa.PrivateKey
 	signMethod jwt.SigningMethod
 	keycache   cache.DataStore
 	validity   time.Duration
 }
 
-// NewConfig initializes a new signer structure
-func NewConfig(publicKey *ecdsa.PublicKey, privateKey *ecdsa.PrivateKey, cacheValiditiy time.Duration) *PKIConfiguration {
+// NewPKIIssuer initializes a new signer structure
+func NewPKIIssuer(privateKey *ecdsa.PrivateKey) PKITokenIssuer {
+
+	return &tokenManager{
+		privateKey: privateKey,
+		signMethod: jwt.SigningMethodES256,
+	}
+}
+
+// NewPKIVerifier returns a new PKIConfiguration.
+func NewPKIVerifier(publicKeys []*ecdsa.PublicKey, cacheValidity time.Duration) PKITokenVerifier {
 
 	validity := defaultValidity * time.Second
-	if cacheValiditiy > 0 {
-		validity = cacheValiditiy
+	if cacheValidity > 0 {
+		validity = cacheValidity
 	}
 
-	return &PKIConfiguration{
-		publicKey:  publicKey,
-		privateKey: privateKey,
+	return &tokenManager{
+		publicKeys: publicKeys,
 		signMethod: jwt.SigningMethodES256,
 		keycache:   cache.NewCacheWithExpiration(validity),
 		validity:   validity,
@@ -53,40 +68,45 @@ func NewConfig(publicKey *ecdsa.PublicKey, privateKey *ecdsa.PrivateKey, cacheVa
 }
 
 // Verify verifies a token and returns the public key
-func (p *PKIConfiguration) Verify(token []byte) (*ecdsa.PublicKey, error) {
+func (p *tokenManager) Verify(token []byte) (*ecdsa.PublicKey, error) {
 
 	tokenString := string(token)
 
-	claims := &VerifierClaims{}
+	claims := &verifierClaims{}
 
 	if pk, err := p.keycache.Get(tokenString); err == nil {
 		return pk.(*ecdsa.PublicKey), nil
 	}
 
-	// Parse the JWT token with the public key recovered
-	jwttoken, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
-		return p.publicKey, nil
-	})
+	var JWTToken *jwt.Token
+	var err error
+	for _, pk := range p.publicKeys {
 
-	if err != nil || !jwttoken.Valid {
-		zap.L().Error("Failed to parse public key structure", zap.Error(err))
-		return nil, fmt.Errorf("error in token %v ", err.Error())
+		JWTToken, err = jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return pk, nil
+		})
+
+		if err != nil || !JWTToken.Valid {
+			continue
+		}
+
+		pk := KeyFromClaims(claims)
+
+		if time.Now().Add(p.validity).Unix() <= claims.ExpiresAt {
+			p.keycache.AddOrUpdate(tokenString, pk)
+		}
+
+		return pk, nil
 	}
 
-	pk := KeyFromClaims(claims)
-
-	if time.Now().Add(p.validity).Unix() <= claims.ExpiresAt {
-		p.keycache.AddOrUpdate(tokenString, pk)
-	}
-
-	return pk, nil
+	return nil, fmt.Errorf("Unable to verify token against any available public key")
 }
 
 // CreateTokenFromCertificate creates and signs a token
-func (p *PKIConfiguration) CreateTokenFromCertificate(cert *x509.Certificate) ([]byte, error) {
+func (p *tokenManager) CreateTokenFromCertificate(cert *x509.Certificate) ([]byte, error) {
 
 	// Combine the application claims with the standard claims
-	claims := &VerifierClaims{
+	claims := &verifierClaims{
 		X: cert.PublicKey.(*ecdsa.PublicKey).X,
 		Y: cert.PublicKey.(*ecdsa.PublicKey).Y,
 	}
@@ -102,7 +122,7 @@ func (p *PKIConfiguration) CreateTokenFromCertificate(cert *x509.Certificate) ([
 }
 
 // KeyFromClaims creates the public key structure from the claims
-func KeyFromClaims(claims *VerifierClaims) *ecdsa.PublicKey {
+func KeyFromClaims(claims *verifierClaims) *ecdsa.PublicKey {
 	return &ecdsa.PublicKey{
 		Curve: elliptic.P256(),
 		X:     claims.X,

--- a/enforcer/utils/rpcwrapper/types.go
+++ b/enforcer/utils/rpcwrapper/types.go
@@ -45,7 +45,7 @@ type InitRequestPayload struct {
 	SecretType             secrets.PrivateSecretsType `json:",omitempty"`
 	ServerID               string                     `json:",omitempty"`
 	CAPEM                  []byte                     `json:",omitempty"`
-	TokenCAPEM             []byte                     `json:",omitempty"`
+	TokenKeyPEMs           [][]byte                   `json:",omitempty"`
 	PublicPEM              []byte                     `json:",omitempty"`
 	PrivatePEM             []byte                     `json:",omitempty"`
 	Token                  []byte                     `json:",omitempty"`

--- a/enforcer/utils/rpcwrapper/types.go
+++ b/enforcer/utils/rpcwrapper/types.go
@@ -45,6 +45,7 @@ type InitRequestPayload struct {
 	SecretType             secrets.PrivateSecretsType `json:",omitempty"`
 	ServerID               string                     `json:",omitempty"`
 	CAPEM                  []byte                     `json:",omitempty"`
+	TokenCAPEM             []byte                     `json:",omitempty"`
 	PublicPEM              []byte                     `json:",omitempty"`
 	PrivatePEM             []byte                     `json:",omitempty"`
 	Token                  []byte                     `json:",omitempty"`

--- a/enforcer/utils/secrets/compactpki_test.go
+++ b/enforcer/utils/secrets/compactpki_test.go
@@ -55,17 +55,13 @@ func createTxtToken() []byte {
 	if err != nil {
 		panic("bad ca key ")
 	}
-	caCert, err := crypto.LoadCertificate([]byte(caPEM))
-	if err != nil {
-		panic("bad ca cert")
-	}
 
 	clientCert, err := crypto.LoadCertificate([]byte(publicPEM))
 	if err != nil {
 		panic("bad client cert ")
 	}
 
-	p := pkiverifier.NewConfig(caCert.PublicKey.(*ecdsa.PublicKey), caKey, -1)
+	p := pkiverifier.NewPKIIssuer(caKey)
 	token, err := p.CreateTokenFromCertificate(clientCert)
 	if err != nil {
 		panic("can't create token")


### PR DESCRIPTION
part of PRs set:
- aporeto-inc/trireme-example#28
- aporeto-inc/barret#2
- aporeto-inc/enforcerd#305
- aporeto-inc/squall#265
- aporeto-inc/addedeffect#22
- aporeto-inc/gaia#67