### PR TITLE
Fixed: Reactivating errcheck for tests

### DIFF
--- a/enforcer/utils/packetgen/interfaces.go
+++ b/enforcer/utils/packetgen/interfaces.go
@@ -58,11 +58,11 @@ type TCPPacketManipulator interface {
 	//Used to return TCP Checksum
 	GetTCPChecksum() uint16
 	//Used to set TCP Sequence number
-	SetTCPSequenceNumber(seqNum uint32) error
+	SetTCPSequenceNumber(seqNum uint32)
 	//Used to set TCP Acknowledgement number
-	SetTCPAcknowledgementNumber(ackNum uint32) error
+	SetTCPAcknowledgementNumber(ackNum uint32)
 	//Used to set TCP Window
-	SetTCPWindow(window uint16) error
+	SetTCPWindow(window uint16)
 	//Used to set TCP Syn flag to true
 	SetTCPSyn()
 	//Used to set TCP Syn and Ack flag to true
@@ -88,7 +88,7 @@ type TCPPacketManipulator interface {
 //PacketHelper interface is a helper for packets and packet flows
 //Optional: not needed for actual usage
 type PacketHelper interface {
-	ToBytes() []byte
+	ToBytes() ([]byte, error)
 	AddPacket(packet gopacket.Packet)
 	DecodePacket() PacketManipulator
 }
@@ -106,7 +106,7 @@ type PacketManipulator interface {
 //Used to create/manipulate packet flows
 type PacketFlowManipulator interface {
 	//Used to create a flow of TCP packets
-	GenerateTCPFlow(pt PacketFlowType) PacketFlowManipulator
+	GenerateTCPFlow(pt PacketFlowType) (PacketFlowManipulator, error)
 	//Used to return first TCP Syn packet
 	GetFirstSynPacket() PacketManipulator
 	//Used to return first TCP SynAck packet

--- a/enforcer/utils/packetgen/packet_gen.go
+++ b/enforcer/utils/packetgen/packet_gen.go
@@ -137,12 +137,7 @@ func (p *Packet) AddTCPLayer(srcPort layers.TCPPort, dstPort layers.TCPPort) err
 		PSH:     false,
 	}
 
-	err := p.tcpLayer.SetNetworkLayerForChecksum(p.ipLayer)
-	if err != nil {
-		return fmt.Errorf("Error: Calculating Checksum %s", err)
-	}
-
-	return nil
+	return p.tcpLayer.SetNetworkLayerForChecksum(p.ipLayer)
 }
 
 //GetTCPPacket returns created TCP packet
@@ -288,16 +283,14 @@ func (p *Packet) ToBytes() ([]byte, error) {
 		ComputeChecksums: true, //compute checksum based on the payload during serialization
 	}
 
-	err := p.tcpLayer.SetNetworkLayerForChecksum(p.ipLayer)
-	if err != nil {
+	if err := p.tcpLayer.SetNetworkLayerForChecksum(p.ipLayer); err != nil {
 		return nil, fmt.Errorf("Error: Calculating Checksum %s", err)
 	}
 
 	//Creating a packet buffer by serializing the ethernet, IP and TCP layers/packets
 	packetBuf := gopacket.NewSerializeBuffer()
 	tcpPayload := gopacket.Payload(p.tcpLayer.Payload)
-	err = gopacket.SerializeLayers(packetBuf, opts, p.ethernetLayer, p.ipLayer, p.tcpLayer, tcpPayload)
-	if err != nil {
+	if err := gopacket.SerializeLayers(packetBuf, opts, p.ethernetLayer, p.ipLayer, p.tcpLayer, tcpPayload); err != nil {
 		return nil, fmt.Errorf("Error: Serializing layers %s", err)
 	}
 	//Converting into bytes and removing the ethernet from the layers
@@ -405,16 +398,13 @@ func (p *PacketFlow) GenerateTCPFlow(pt PacketFlowType) (PacketFlowManipulator, 
 	if pt == 0 {
 		//Create a SYN packet to initialize the flow
 		firstPacket := NewPacket()
-		err := firstPacket.AddEthernetLayer(p.sMAC, p.dMAC)
-		if err != nil {
+		if err := firstPacket.AddEthernetLayer(p.sMAC, p.dMAC); err != nil {
 			return nil, fmt.Errorf("Error: Adding ethernet layer %s", err)
 		}
-		err = firstPacket.AddIPLayer(p.sIP, p.dIP)
-		if err != nil {
+		if err := firstPacket.AddIPLayer(p.sIP, p.dIP); err != nil {
 			return nil, fmt.Errorf("Error: Adding ip layer %s", err)
 		}
-		err = firstPacket.AddTCPLayer(p.sPort, p.dPort)
-		if err != nil {
+		if err := firstPacket.AddTCPLayer(p.sPort, p.dPort); err != nil {
 			return nil, fmt.Errorf("Error: Adding tcp layer %s", err)
 		}
 		firstPacket.SetTCPSyn()
@@ -426,16 +416,13 @@ func (p *PacketFlow) GenerateTCPFlow(pt PacketFlowType) (PacketFlowManipulator, 
 
 		//Create a SynAck packet
 		secondPacket := NewPacket()
-		err = secondPacket.AddEthernetLayer(p.sMAC, p.dMAC)
-		if err != nil {
+		if err := secondPacket.AddEthernetLayer(p.sMAC, p.dMAC); err != nil {
 			return nil, fmt.Errorf("Error: Adding ethernet layer %s", err)
 		}
-		err = secondPacket.AddIPLayer(p.dIP, p.sIP)
-		if err != nil {
+		if err := secondPacket.AddIPLayer(p.dIP, p.sIP); err != nil {
 			return nil, fmt.Errorf("Error: Adding ip layer %s", err)
 		}
-		err = secondPacket.AddTCPLayer(p.dPort, p.sPort)
-		if err != nil {
+		if err := secondPacket.AddTCPLayer(p.dPort, p.sPort); err != nil {
 			return nil, fmt.Errorf("Error: Adding tcp layer %s", err)
 		}
 		secondPacket.SetTCPSynAck()
@@ -447,16 +434,13 @@ func (p *PacketFlow) GenerateTCPFlow(pt PacketFlowType) (PacketFlowManipulator, 
 
 		//Create an Ack Packet
 		thirdPacket := NewPacket()
-		err = thirdPacket.AddEthernetLayer(p.sMAC, p.dMAC)
-		if err != nil {
+		if err := thirdPacket.AddEthernetLayer(p.sMAC, p.dMAC); err != nil {
 			return nil, fmt.Errorf("Error: Adding ethernet layer %s", err)
 		}
-		err = thirdPacket.AddIPLayer(p.sIP, p.dIP)
-		if err != nil {
+		if err := thirdPacket.AddIPLayer(p.sIP, p.dIP); err != nil {
 			return nil, fmt.Errorf("Error: Adding ip layer %s", err)
 		}
-		err = thirdPacket.AddTCPLayer(p.sPort, p.dPort)
-		if err != nil {
+		if err := thirdPacket.AddTCPLayer(p.sPort, p.dPort); err != nil {
 			return nil, fmt.Errorf("Error: Adding tcp layer %s", err)
 		}
 		thirdPacket.SetTCPAck()

--- a/monitor/linuxmonitor/cgnetcls/cgnetcls_test.go
+++ b/monitor/linuxmonitor/cgnetcls/cgnetcls_test.go
@@ -24,15 +24,11 @@ const (
 	testmark             = 100
 )
 
-func cleanupnetclsgroup(err *error) {
+func cleanupnetclsgroup() {
 	data, _ := ioutil.ReadFile(filepath.Join(basePath, TriremeBasePath, testcgroupname, procs))
 	fmt.Println(string(data))
-	if werr := ioutil.WriteFile(filepath.Join(basePath, procs), data, 0644); werr != nil {
-		*err = fmt.Errorf("Error: Writing file %s", werr.Error())
-	}
-	if rerr := os.RemoveAll(filepath.Join(basePath, TriremeBasePath, testcgroupname)); rerr != nil {
-		*err = fmt.Errorf("Error: Removing file %s", rerr.Error())
-	}
+	_ = ioutil.WriteFile(filepath.Join(basePath, procs), data, 0644)
+	_ = os.RemoveAll(filepath.Join(basePath, TriremeBasePath, testcgroupname))
 }
 
 func TestCreategroup(t *testing.T) {
@@ -46,11 +42,8 @@ func TestCreategroup(t *testing.T) {
 		//Check if all the files required are created
 		t.Errorf("Failed to create group error returned %s", err.Error())
 	}
-	var cerr error
-	defer cleanupnetclsgroup(&cerr)
-	if cerr != nil {
-		t.Errorf("Failed to clean cgroup %s", cerr.Error())
-	}
+
+	defer cleanupnetclsgroup()
 
 	if _, err := ioutil.ReadFile(filepath.Join(basePath, releaseAgentConfFile)); err != nil {
 		if os.IsNotExist(err) {
@@ -111,11 +104,9 @@ func TestAssignMark(t *testing.T) {
 		t.Errorf("Error creating cgroup %s", err)
 		t.SkipNow()
 	}
-	var cerr error
-	defer cleanupnetclsgroup(&cerr)
-	if cerr != nil {
-		t.Errorf("Failed to clean cgroup %s", cerr.Error())
-	}
+
+	defer cleanupnetclsgroup()
+
 	if err := cg.AssignMark(testcgroupnameformat, testmark); err != nil {
 		t.Errorf("Failed to assign mark error = %s", err.Error())
 		t.SkipNow()
@@ -131,7 +122,6 @@ func TestAssignMark(t *testing.T) {
 			t.SkipNow()
 		}
 	}
-
 }
 
 func TestAddProcess(t *testing.T) {
@@ -151,11 +141,9 @@ func TestAddProcess(t *testing.T) {
 		t.Errorf("Error creating cgroup")
 		t.SkipNow()
 	}
-	var cerr error
-	defer cleanupnetclsgroup(&cerr)
-	if cerr != nil {
-		t.Errorf("Failed to clean cgroup %s", cerr.Error())
-	}
+
+	defer cleanupnetclsgroup()
+
 	//Add a non-existent process
 	//loop to find non-existent pid
 	for {
@@ -196,11 +184,9 @@ func TestRemoveProcess(t *testing.T) {
 		t.Errorf("Error creating cgroup")
 		t.SkipNow()
 	}
-	var cerr error
-	defer cleanupnetclsgroup(&cerr)
-	if cerr != nil {
-		t.Errorf("Failed to clean cgroup %s", cerr.Error())
-	}
+
+	defer cleanupnetclsgroup()
+
 	if err := cg.AddProcess(testcgroupname, 1); err != nil {
 		t.Errorf("Error adding process")
 		t.SkipNow()
@@ -229,11 +215,9 @@ func TestDeleteCgroup(t *testing.T) {
 		t.Errorf("Failed to create cgroup %s", err.Error())
 		t.SkipNow()
 	}
-	var cerr error
-	defer cleanupnetclsgroup(&cerr)
-	if cerr != nil {
-		t.Errorf("Failed to clean cgroup %s", cerr.Error())
-	}
+
+	defer cleanupnetclsgroup()
+
 	if err := cg.DeleteCgroup(testcgroupname); err != nil {
 		t.Errorf("Failed to delete cgroup %s", err.Error())
 		t.SkipNow()
@@ -250,11 +234,9 @@ func TestDeleteBasePath(t *testing.T) {
 	if err := cg.DeleteCgroup(testcgroupname); err != nil {
 		t.Errorf("Delete of group failed %s", err.Error())
 	}
-	var cerr error
-	defer cleanupnetclsgroup(&cerr)
-	if cerr != nil {
-		t.Errorf("Failed to clean cgroup %s", cerr.Error())
-	}
+
+	defer cleanupnetclsgroup()
+
 	cg.Deletebasepath(testcgroupnameformat)
 	_, err := os.Stat(filepath.Join(basePath, TriremeBasePath, testcgroupname))
 	if err == nil {
@@ -284,11 +266,9 @@ func TestListCgroupProcesses(t *testing.T) {
 		t.Errorf("Error creating cgroup")
 		t.SkipNow()
 	}
-	var cerr error
-	defer cleanupnetclsgroup(&cerr)
-	if cerr != nil {
-		t.Errorf("Failed to clean cgroup %s", cerr.Error())
-	}
+
+	defer cleanupnetclsgroup()
+
 	//Add a non-existent process
 	//loop to find non-existent pid
 	for {

--- a/monitor/linuxmonitor/cgnetcls/cgnetcls_test.go
+++ b/monitor/linuxmonitor/cgnetcls/cgnetcls_test.go
@@ -27,12 +27,10 @@ const (
 func cleanupnetclsgroup(err *error) {
 	data, _ := ioutil.ReadFile(filepath.Join(basePath, TriremeBasePath, testcgroupname, procs))
 	fmt.Println(string(data))
-	werr := ioutil.WriteFile(filepath.Join(basePath, procs), data, 0644)
-	if werr != nil {
+	if werr := ioutil.WriteFile(filepath.Join(basePath, procs), data, 0644); werr != nil {
 		*err = fmt.Errorf("Error: Writing file %s", werr.Error())
 	}
-	rerr := os.RemoveAll(filepath.Join(basePath, TriremeBasePath, testcgroupname))
-	if rerr != nil {
+	if rerr := os.RemoveAll(filepath.Join(basePath, TriremeBasePath, testcgroupname)); rerr != nil {
 		*err = fmt.Errorf("Error: Removing file %s", rerr.Error())
 	}
 }
@@ -44,12 +42,14 @@ func TestCreategroup(t *testing.T) {
 	}
 
 	cg := NewCgroupNetController("")
-	err := cg.Creategroup(testcgroupnameformat)
-	defer cleanupnetclsgroup(&err)
-
-	//Check if all the files required are created
-	if err != nil {
+	if err := cg.Creategroup(testcgroupnameformat); err != nil {
+		//Check if all the files required are created
 		t.Errorf("Failed to create group error returned %s", err.Error())
+	}
+	var cerr error
+	defer cleanupnetclsgroup(&cerr)
+	if cerr != nil {
+		t.Errorf("Failed to clean cgroup %s", cerr.Error())
 	}
 
 	if _, err := ioutil.ReadFile(filepath.Join(basePath, releaseAgentConfFile)); err != nil {
@@ -94,9 +94,7 @@ func TestCreategroup(t *testing.T) {
 			t.SkipNow()
 		}
 	}
-
 	return
-
 }
 
 func TestAssignMark(t *testing.T) {
@@ -105,19 +103,20 @@ func TestAssignMark(t *testing.T) {
 		t.SkipNow()
 	}
 	//Assigning mark before creating group
-	err := cg.AssignMark(testcgroupname, testmark)
-	if err == nil {
+	if err := cg.AssignMark(testcgroupname, testmark); err == nil {
 		t.Errorf("Assign mark succeeded without a valid group being present ")
 		t.SkipNow()
 	}
-	err = cg.Creategroup(testcgroupnameformat)
-	if err == nil {
+	if err := cg.Creategroup(testcgroupnameformat); err != nil {
 		t.Errorf("Error creating cgroup %s", err)
 		t.SkipNow()
 	}
-	defer cleanupnetclsgroup(&err)
-	err = cg.AssignMark(testcgroupnameformat, testmark)
-	if err != nil {
+	var cerr error
+	defer cleanupnetclsgroup(&cerr)
+	if cerr != nil {
+		t.Errorf("Failed to clean cgroup %s", cerr.Error())
+	}
+	if err := cg.AssignMark(testcgroupnameformat, testmark); err != nil {
 		t.Errorf("Failed to assign mark error = %s", err.Error())
 		t.SkipNow()
 	} else {
@@ -144,45 +143,43 @@ func TestAddProcess(t *testing.T) {
 	}
 	cg := NewCgroupNetController("")
 	//AddProcess to a non-existent group
-	err := cg.AddProcess(testcgroupname, os.Getpid())
-	if err == nil {
+	if err := cg.AddProcess(testcgroupname, os.Getpid()); err == nil {
 		t.Errorf("Process successfully added to a non existent group")
 		t.SkipNow()
 	}
-	err = cg.Creategroup(testcgroupnameformat)
-	if err != nil {
+	if err := cg.Creategroup(testcgroupnameformat); err != nil {
 		t.Errorf("Error creating cgroup")
 		t.SkipNow()
 	}
-	defer cleanupnetclsgroup(&err)
+	var cerr error
+	defer cleanupnetclsgroup(&cerr)
+	if cerr != nil {
+		t.Errorf("Failed to clean cgroup %s", cerr.Error())
+	}
 	//Add a non-existent process
 	//loop to find non-existent pid
 	for {
-		if err = syscall.Kill(pid, 0); err != nil {
+		if err := syscall.Kill(pid, 0); err != nil {
 			break
 		}
 		pid = r.Int()
 
 	}
-	err = cg.AddProcess(testcgroupnameformat, pid)
-	if err != nil {
+	if err := cg.AddProcess(testcgroupnameformat, pid); err != nil {
 		t.Errorf("Unexpected error not returned for non-existent process")
 		t.SkipNow()
 	}
 	pid = 1 //Guaranteed to be present
-	err = cg.AddProcess(testcgroupname, pid)
-	if err != nil {
+	if err := cg.AddProcess(testcgroupname, pid); err != nil {
 		t.Errorf("Failed to add process %s", err.Error())
 		t.SkipNow()
 	} else {
 		//This directory structure should not be delete
-		err = os.RemoveAll(filepath.Join(basePath, TriremeBasePath, testcgroupname))
-		if err == nil {
+		if err := os.RemoveAll(filepath.Join(basePath, TriremeBasePath, testcgroupname)); err == nil {
 			t.Errorf("Process not added to cgroup")
 			t.SkipNow()
 		}
 	}
-
 }
 
 func TestRemoveProcess(t *testing.T) {
@@ -191,29 +188,28 @@ func TestRemoveProcess(t *testing.T) {
 	}
 	cg := NewCgroupNetController("")
 	//Removing process from non-existent group
-	err := cg.RemoveProcess(testcgroupname, 1)
-	if err == nil {
+	if err := cg.RemoveProcess(testcgroupname, 1); err == nil {
 		t.Errorf("RemoveProcess succeeded without valid group being present ")
 		t.SkipNow()
 	}
-	err = cg.Creategroup(testcgroupnameformat)
-	if err != nil {
+	if err := cg.Creategroup(testcgroupnameformat); err != nil {
 		t.Errorf("Error creating cgroup")
 		t.SkipNow()
 	}
-	defer cleanupnetclsgroup(&err)
-	err = cg.AddProcess(testcgroupname, 1)
-	if err != nil {
+	var cerr error
+	defer cleanupnetclsgroup(&cerr)
+	if cerr != nil {
+		t.Errorf("Failed to clean cgroup %s", cerr.Error())
+	}
+	if err := cg.AddProcess(testcgroupname, 1); err != nil {
 		t.Errorf("Error adding process")
 		t.SkipNow()
 	}
-	err = cg.RemoveProcess(testcgroupnameformat, 10)
-	if err == nil {
+	if err := cg.RemoveProcess(testcgroupnameformat, 10); err == nil {
 		t.Errorf("Removed process which was not a part of this cgroup")
 		t.SkipNow()
 	}
-	err = cg.RemoveProcess(testcgroupname, 1)
-	if err != nil {
+	if err := cg.RemoveProcess(testcgroupname, 1); err != nil {
 		t.Errorf("Failed to remove process %s", err.Error())
 		t.SkipNow()
 	}
@@ -225,21 +221,20 @@ func TestDeleteCgroup(t *testing.T) {
 	}
 	cg := NewCgroupNetController("")
 	//Removing process from non-existent group
-	err := cg.DeleteCgroup(testcgroupnameformat)
-	if err != nil {
+	if err := cg.DeleteCgroup(testcgroupnameformat); err != nil {
 		t.Errorf("Non-existent cgroup delelte returned an error")
 		t.SkipNow()
 	}
-	err = cg.Creategroup(testcgroupname)
-
-	if err != nil {
+	if err := cg.Creategroup(testcgroupname); err != nil {
 		t.Errorf("Failed to create cgroup %s", err.Error())
 		t.SkipNow()
 	}
-
-	defer cleanupnetclsgroup(&err)
-	err = cg.DeleteCgroup(testcgroupname)
-	if err != nil {
+	var cerr error
+	defer cleanupnetclsgroup(&cerr)
+	if cerr != nil {
+		t.Errorf("Failed to clean cgroup %s", cerr.Error())
+	}
+	if err := cg.DeleteCgroup(testcgroupname); err != nil {
 		t.Errorf("Failed to delete cgroup %s", err.Error())
 		t.SkipNow()
 	}
@@ -252,14 +247,16 @@ func TestDeleteBasePath(t *testing.T) {
 	}
 	cg := NewCgroupNetController("")
 	//Removing process from non-existent group
-	err := cg.DeleteCgroup(testcgroupname)
-	if err != nil {
+	if err := cg.DeleteCgroup(testcgroupname); err != nil {
 		t.Errorf("Delete of group failed %s", err.Error())
 	}
-
-	defer cleanupnetclsgroup(&err)
+	var cerr error
+	defer cleanupnetclsgroup(&cerr)
+	if cerr != nil {
+		t.Errorf("Failed to clean cgroup %s", cerr.Error())
+	}
 	cg.Deletebasepath(testcgroupnameformat)
-	_, err = os.Stat(filepath.Join(basePath, TriremeBasePath, testcgroupname))
+	_, err := os.Stat(filepath.Join(basePath, TriremeBasePath, testcgroupname))
 	if err == nil {
 		t.Errorf("Delete of cgroup from system failed %s", err.Error())
 		t.SkipNow()
@@ -279,17 +276,19 @@ func TestListCgroupProcesses(t *testing.T) {
 		t.Errorf("No process found but succeeded")
 	}
 	//AddProcess to a non-existent group
-	err = cg.AddProcess(testcgroupname, os.Getpid())
-	if err == nil {
+	if err = cg.AddProcess(testcgroupname, os.Getpid()); err == nil {
 		t.Errorf("Process successfully added to a non existent group")
 		t.SkipNow()
 	}
-	err = cg.Creategroup(testcgroupname)
-	if err != nil {
+	if err = cg.Creategroup(testcgroupname); err != nil {
 		t.Errorf("Error creating cgroup")
 		t.SkipNow()
 	}
-	defer cleanupnetclsgroup(&err)
+	var cerr error
+	defer cleanupnetclsgroup(&cerr)
+	if cerr != nil {
+		t.Errorf("Failed to clean cgroup %s", cerr.Error())
+	}
 	//Add a non-existent process
 	//loop to find non-existent pid
 	for {
@@ -301,14 +300,12 @@ func TestListCgroupProcesses(t *testing.T) {
 	}
 
 	pid = 1 //Guaranteed to be present
-	err = cg.AddProcess(testcgroupname, pid)
-	if err != nil {
+	if err = cg.AddProcess(testcgroupname, pid); err != nil {
 		t.Errorf("Failed to add process %s", err.Error())
 		t.SkipNow()
 	} else {
 		//This directory structure should not be delete
-		err = os.RemoveAll(filepath.Join(basePath, TriremeBasePath, testcgroupname))
-		if err == nil {
+		if err = os.RemoveAll(filepath.Join(basePath, TriremeBasePath, testcgroupname)); err == nil {
 			t.Errorf("Process not added to cgroup")
 			t.SkipNow()
 		}


### PR DESCRIPTION
This PR removes nolint and reactivates **errcheck** for tests in datapath and cgnetcls

https://github.com/aporeto-inc/trireme/issues/385
